### PR TITLE
[Feat] PDF 페이지에 따른 자동 스크롤 수정

### DIFF
--- a/Project/Reazy/Views/PDF/Menu/FigureCell.swift
+++ b/Project/Reazy/Views/PDF/Menu/FigureCell.swift
@@ -48,9 +48,9 @@ struct PDFKitView: UIViewRepresentable {
 struct FigureCell: View {
     
     @EnvironmentObject var mainPDFViewModel: MainPDFViewModel
-    let index: Int
     
-    var onSelect: (PDFDocument, String) -> Void
+    let index: Int
+    let onSelect: (PDFDocument, String) -> Void
     
     @State private var aspectRatio: CGFloat = 1.0
     

--- a/Project/Reazy/Views/PDF/Menu/FigureView.swift
+++ b/Project/Reazy/Views/PDF/Menu/FigureView.swift
@@ -6,9 +6,7 @@
 //
 
 import SwiftUI
-import Foundation
 import PDFKit
-import Combine
 
 // MARK: - Lucid : Figure 뷰
 struct FigureView: View {
@@ -38,7 +36,7 @@ struct FigureView: View {
                     }
                 }
                 .listStyle(.plain)
-                .onChange(of: scrollToIndex) { oldValue, newValue in
+                .onChange(of: scrollToIndex) { _, newValue in
                     if let index = newValue {
                         withAnimation {
                             // 자동 스크롤
@@ -49,7 +47,7 @@ struct FigureView: View {
             }
         }
         // 원문보기 페이지 변경시 자동 스크롤
-        .onChange(of: mainPDFViewModel.changedPageNumber) { oldValue, newValue in
+        .onChange(of: mainPDFViewModel.changedPageNumber) { _, newValue in
             
             let pageCount = mainPDFViewModel.figureAnnotations.count
             var foundIndex: Int? = nil


### PR DESCRIPTION
## 변경 사항
- [x] PDF 문서 이동에 따라 해당하는 fig와 table 이미지가 상단에 자동 스크롤되도록 구현하였습니다
- [x] SwiftUI에서 필요없는 setupBindings()를 없애고 .onAppear를 .onChange로 바꾸어 정리하였습니다.
- [x] .onChange { oldValue, newValue in } 으로 바꿔서 노란줄을 해결하였습니다.
- [x] 'OriginalViewModel -> MainPDFViewModel'로 이름을 변경하였습니다.

close #54 

## 스크린샷 or 영상 링크
|
https://github.com/user-attachments/assets/d1091259-717a-4a26-88e6-4c40b47722af
영상 드래그 앤 드롭 했는데, 왜 저는 영상이 다운형식으로 들어오나요ㅠ


## 팀원에게 전달할 사항(Optional)
|
예... 뭐... 이것저것 했습니다...

집중모드에서도 자동 스크롤을 적용하려 했지만, 제가 이해한 바로는 각 문단마다 pdf 한페이지로 인식되어 원래 몇페이지였는지 알기가 쉽지 않은것 같습니다.
