### PR TITLE
[Fix] 원문 <-> 집중 바뀔 때마다 버튼 5개 상태 초기화

### DIFF
--- a/Project/Reazy/Views/PDF/MainPDFView.swift
+++ b/Project/Reazy/Views/PDF/MainPDFView.swift
@@ -213,6 +213,10 @@ struct MainPDFView: View {
                                 }
                             }
                         }
+                        .onChange(of: selectedMode) {
+                            // 원문 <-> 집중 바뀔 때마다 버튼 5개 상태 초기화
+                            selectedButton = nil
+                        }
                         .ignoresSafeArea()
                     }
                 }


### PR DESCRIPTION
## 변경 사항
- [x] 원문 <-> 집중 바뀔 때마다 버튼 5개 상태 초기화

## 스크린샷 or 영상 링크
| 생략


## 팀원에게 전달할 사항(Optional)
- release 1 에서 버튼 다섯 개 집중모드에서 없앨 거라 기능적으로도 초기화 시켰어요 

