### PR TITLE
[Fix] Custom 아이콘 적용 후 색상이 입혀지지 않는 문제 해결

### DIFF
--- a/Project/Reazy/DesignSystem/Views/Buttons.swift
+++ b/Project/Reazy/DesignSystem/Views/Buttons.swift
@@ -20,8 +20,10 @@ enum WriteButton: String, CaseIterable {
       return Image(systemName: "text.bubble")
     case .highlight:
       return Image("Highlight")
+            .renderingMode(.template)
     case .pencil:
       return Image("Pencil")
+            .renderingMode(.template)
     case .eraser:
       return Image(systemName: "eraser")
     case .translate:


### PR DESCRIPTION
## 변경 사항
- [ ] Custom 아이콘 적용 후 색상이 입혀지지 않는 문제가 있었습니다!
만약, svg 파일로 custom icon을 적용하실 경우, 색을 입히기 위해서는 반드시 아래의 코드를 추가해 주세요!
``` Swift
Image("Highlight")
    .renderingMode(.template) // 이거!!
```

## 팀원에게 전달할 사항(Optional)
> 파이탱~!
<img src="https://github.com/user-attachments/assets/f982239f-2e08-4a10-8bf0-013f3bd0f560" width="450"/>


close #98 