### PR TITLE
[Fix] SplitView 진입 시 MainView가 새로고침되는 문제 해결

### DIFF
--- a/Project/Reazy/Views/PDF/Floating/FloatingSplitView.swift
+++ b/Project/Reazy/Views/PDF/Floating/FloatingSplitView.swift
@@ -8,157 +8,166 @@
 import SwiftUI
 import PDFKit
 
+struct SplitDocumentDetails {
+    var documentID: String
+    var document: PDFDocument
+    var head: String
+}
+
 struct FloatingSplitView: View {
-  
-  @EnvironmentObject var mainPDFViewModel: MainPDFViewModel
-  @EnvironmentObject var floatingViewModel: FloatingViewModel
-  
-  @ObservedObject var observableDocument: ObservableDocument
-  
-  let documentID: String
-  let document: PDFDocument
-  let head: String
-  let isFigSelected: Bool
-  let onSelect: () -> Void
-  
-  init(documentID: String, document: PDFDocument, head: String, isFigSelected: Bool, onSelect: @escaping () -> Void) {
-    self.document = document
-    _observableDocument = ObservedObject(wrappedValue: ObservableDocument(document: document))
     
-    self.documentID = documentID
-    self.head = head
-    self.isFigSelected = isFigSelected
-    self.onSelect = onSelect
-  }
-  
-  @State private var isVertical = false
-  
-  var body: some View {
-    GeometryReader { geometry in
-      VStack(spacing: 0) {
-        ZStack {
-          HStack(spacing: 0) {
-            Button(action: {
-              floatingViewModel.setFloatingDocument(documentID: documentID)
-            }, label: {
-              Image(systemName: "rectangle")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.gray600)
-            })
-            .padding(.horizontal, 20)
-            
-            Button(action: {
-              onSelect()
-            }, label: {
-              Image(systemName: isVertical ? "arrow.left.arrow.right" : "arrow.up.arrow.down")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.gray600)
-            })
-            
-            Spacer()
-            
-            Button(action: {
-              floatingViewModel.deselect(documentID: documentID)
-            }, label: {
-              Image(systemName: "xmark")
-                .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(.gray600)
-            })
-            .padding(.trailing, 20)
-          }
-          
-          HStack(spacing: 0) {
-            Spacer()
-            Button(action: {
-              floatingViewModel.moveToPreviousFigure(mainPDFViewModel: mainPDFViewModel, observableDocument: observableDocument)
-            }, label: {
-              Image(systemName: "chevron.left")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.gray600)
-            })
-            Text(head)
-              .reazyFont(.h3)
-              .foregroundStyle(.gray800)
-              .padding(.horizontal, 24)
-            Button(action: {
-              floatingViewModel.moveToNextFigure(mainPDFViewModel: mainPDFViewModel, observableDocument: observableDocument)
-            }, label: {
-              Image(systemName: "chevron.right")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.gray600)
-            })
-            Spacer()
-          }
-        }
-        .padding(.vertical, 10)
+    @EnvironmentObject var mainPDFViewModel: MainPDFViewModel
+    @EnvironmentObject var floatingViewModel: FloatingViewModel
+    
+    @ObservedObject var observableDocument: ObservableDocument
+    
+    let documentID: String
+    let document: PDFDocument
+    let head: String
+    let isFigSelected: Bool
+    let onSelect: () -> Void
+    
+    init(documentID: String, document: PDFDocument, head: String, isFigSelected: Bool, onSelect: @escaping () -> Void) {
+        self.document = document
+        _observableDocument = ObservedObject(wrappedValue: ObservableDocument(document: document))
         
-        Divider()
-          .background(.gray300)
-        
-        PDFKitView(document: observableDocument.document, isScrollEnabled: true)
-          .id(observableDocument.document)
-          .padding(.horizontal, 30)
-          .padding(.vertical, 14)
-        
-        
-        if isFigSelected {
-          Divider()
-          
-          ScrollViewReader { proxy in
-            ScrollView(.horizontal) {
-              HStack(spacing: 8) {
-                ForEach(0..<mainPDFViewModel.figureAnnotations.count, id: \.self) { index in
-                  FigureCell(index: index, onSelect: { newDocumentID, newDocument, newHead in
-                    if floatingViewModel.selectedFigureCellID != newDocumentID {
-                      floatingViewModel.updateSplitDocument(with: newDocument, documentID: newDocumentID, head: newHead)
-                      observableDocument.updateDocument(to: newDocument)
-                      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        withAnimation {
-                          proxy.scrollTo(index, anchor: .center)
-                        }
-                      }
+        self.documentID = documentID
+        self.head = head
+        self.isFigSelected = isFigSelected
+        self.onSelect = onSelect
+    }
+    
+    @State private var isVertical = false
+    
+    var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                ZStack {
+                    HStack(spacing: 0) {
+                        Button(action: {
+                            floatingViewModel.setFloatingDocument(documentID: documentID)
+                        }, label: {
+                            Image(systemName: "rectangle")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.gray600)
+                        })
+                        .padding(.horizontal, 20)
+                        
+                        Button(action: {
+                            onSelect()
+                        }, label: {
+                            Image(systemName: isVertical ? "arrow.left.arrow.right" : "arrow.up.arrow.down")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.gray600)
+                        })
+                        
+                        Spacer()
+                        
+                        Button(action: {
+                            floatingViewModel.deselect(documentID: documentID)
+                        }, label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundStyle(.gray600)
+                        })
+                        .padding(.trailing, 20)
                     }
-                  })
-                  .environmentObject(mainPDFViewModel)
-                  .environmentObject(floatingViewModel)
-                  .padding(.trailing, 5)
-                  .id(index)
+                    
+                    HStack(spacing: 0) {
+                        Spacer()
+                        Button(action: {
+                            floatingViewModel.moveToPreviousFigure(mainPDFViewModel: mainPDFViewModel, observableDocument: observableDocument)
+                        }, label: {
+                            Image(systemName: "chevron.left")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.gray600)
+                        })
+                        Text(head)
+                            .reazyFont(.h3)
+                            .foregroundStyle(.gray800)
+                            .padding(.horizontal, 24)
+                        Button(action: {
+                            floatingViewModel.moveToNextFigure(mainPDFViewModel: mainPDFViewModel, observableDocument: observableDocument)
+                        }, label: {
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.gray600)
+                        })
+                        Spacer()
+                    }
                 }
-              }
-              .padding(.horizontal, 20)
-              .padding(.vertical, 24)
+                .padding(.vertical, 10)
+                
+                Rectangle()
+                    .frame(height: 1)
+                    .foregroundStyle(.gray300)
+                
+                PDFKitView(document: observableDocument.document, isScrollEnabled: true)
+                    .id(observableDocument.document)
+                    .padding(.horizontal, 30)
+                    .padding(.vertical, 14)
+                
+                
+                if isFigSelected {
+                    Rectangle()
+                        .frame(height: 1)
+                        .foregroundStyle(.gray300)
+                    
+                    ScrollViewReader { proxy in
+                        ScrollView(.horizontal) {
+                            HStack(spacing: 8) {
+                                ForEach(0..<mainPDFViewModel.figureAnnotations.count, id: \.self) { index in
+                                    FigureCell(index: index, onSelect: { newDocumentID, newDocument, newHead in
+                                        if floatingViewModel.selectedFigureCellID != newDocumentID {
+                                            floatingViewModel.updateSplitDocument(with: newDocument, documentID: newDocumentID, head: newHead)
+                                            observableDocument.updateDocument(to: newDocument)
+                                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                                withAnimation {
+                                                    proxy.scrollTo(index, anchor: .center)
+                                                }
+                                            }
+                                        }
+                                    })
+                                    .environmentObject(mainPDFViewModel)
+                                    .environmentObject(floatingViewModel)
+                                    .padding(.trailing, 5)
+                                    .id(index)
+                                }
+                            }
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 24)
+                        }
+                        .onAppear {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                withAnimation {
+                                    proxy.scrollTo(floatingViewModel.selectedFigureIndex, anchor: .center)
+                                }
+                            }
+                        }
+                        .onChange(of: floatingViewModel.selectedFigureIndex) { oldIndex , newIndex in
+                            if oldIndex != newIndex {
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                    withAnimation {
+                                        proxy.scrollTo(newIndex, anchor: .center)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .frame(height: isVertical ? geometry.size.height * 0.2 : geometry.size.height * 0.3)
+                }
             }
             .onAppear {
-              DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                withAnimation {
-                  proxy.scrollTo(floatingViewModel.selectedFigureIndex, anchor: .center)
-                }
-              }
+                updateOrientation(with: geometry)
             }
-            .onChange(of: floatingViewModel.selectedFigureIndex) { oldIndex , newIndex in
-              if oldIndex != newIndex {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                  withAnimation {
-                    proxy.scrollTo(newIndex, anchor: .center)
-                  }
-                }
-              }
+            .onChange(of: geometry.size) {
+                updateOrientation(with: geometry)
             }
-          }
-          .frame(height: isVertical ? geometry.size.height * 0.2 : geometry.size.height * 0.3)
         }
-      }
-      .onAppear {
-        updateOrientation(with: geometry)
-      }
-      .onChange(of: geometry.size) {
-        updateOrientation(with: geometry)
-      }
     }
-  }
-  
-  // 기기의 방향에 따라 isVertical 상태를 업데이트하는 함수
-  private func updateOrientation(with geometry: GeometryProxy) {
-    isVertical = geometry.size.height > geometry.size.width
-  }
+    
+    // 기기의 방향에 따라 isVertical 상태를 업데이트하는 함수
+    private func updateOrientation(with geometry: GeometryProxy) {
+        isVertical = geometry.size.height > geometry.size.width
+    }
 }

--- a/Project/Reazy/Views/PDF/Floating/FloatingViewModel.swift
+++ b/Project/Reazy/Views/PDF/Floating/FloatingViewModel.swift
@@ -136,10 +136,14 @@ class FloatingViewModel: ObservableObject {
     selectedFigureIndex = index
   }
   
-  func getSplitDocumentDetails() -> (documentID: String, document: PDFDocument, head: String)? {
+    func getSplitDocumentDetails() -> SplitDocumentDetails? {
     guard splitMode, let selectedID = selectedFigureCellID else { return nil }
     if let selectedFigure = droppedFigures.first(where: { $0.documentID == selectedID }) {
-      return (documentID: selectedFigure.documentID, document: selectedFigure.document, head: selectedFigure.head)
+        return SplitDocumentDetails(
+            documentID: selectedFigure.documentID,
+            document: selectedFigure.document,
+            head: selectedFigure.head
+        )
     }
     return nil
   }

--- a/Project/Reazy/Views/PDF/Menu/FigureView.swift
+++ b/Project/Reazy/Views/PDF/Menu/FigureView.swift
@@ -12,7 +12,7 @@ import PDFKit
 struct FigureView: View {
     
     @EnvironmentObject var mainPDFViewModel: MainPDFViewModel
-  
+    
     @State private var scrollToIndex: Int? = nil
     let onSelect: (String, PDFDocument, String) -> Void
     
@@ -27,57 +27,58 @@ struct FigureView: View {
                     .reazyFont(.text2)
                     .foregroundStyle(.gray600)
                     .padding(.vertical, 24)
-            }
-            
-            // ScrollViewReader로 자동 스크롤 구현
-            ScrollViewReader { proxy in
-                List {
-                    ForEach(0..<mainPDFViewModel.figureAnnotations.count, id: \.self) { index in
-                        FigureCell(index: index, onSelect: onSelect)
-                            .padding(.bottom, 21)
-                            .listRowSeparator(.hidden)
-                    }
-                }
-                .padding(.horizontal, 10)
-                .listStyle(.plain)
-                .onChange(of: scrollToIndex) { _, newValue in
-                    if let index = newValue {
-                      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        withAnimation {
-                          // 자동 스크롤
-                          proxy.scrollTo(index, anchor: .top)
+                
+                
+                // ScrollViewReader로 자동 스크롤 구현
+                ScrollViewReader { proxy in
+                    List {
+                        ForEach(0..<mainPDFViewModel.figureAnnotations.count, id: \.self) { index in
+                            FigureCell(index: index, onSelect: onSelect)
+                                .padding(.bottom, 21)
+                                .listRowSeparator(.hidden)
                         }
-                      }
+                    }
+                    .padding(.horizontal, 10)
+                    .listStyle(.plain)
+                    .onChange(of: scrollToIndex) { _, newValue in
+                        if let index = newValue {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                                withAnimation {
+                                    // 자동 스크롤
+                                    proxy.scrollTo(index, anchor: .top)
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
         // 원문보기 페이지 변경시 자동 스크롤
         .onChange(of: mainPDFViewModel.changedPageNumber) { _, newValue in
-          updateScrollIndex(for: newValue)
+            updateScrollIndex(for: newValue)
         }
     }
-  
-  private func updateScrollIndex(for pageNumber: Int) {
-    let pageCount = mainPDFViewModel.figureAnnotations.count
-    var foundIndex: Int? = nil
     
-    for index in 0..<pageCount {
-      if mainPDFViewModel.figureAnnotations[index].page == pageNumber {
-        foundIndex = index
-        break
-      }
-    }
-    
-    if let index = foundIndex {
-      scrollToIndex = index + 1
-    } else {
-      for index in 0..<pageCount {
-        if mainPDFViewModel.figureAnnotations[index].page > pageNumber {
-          scrollToIndex = index
-          break
+    private func updateScrollIndex(for pageNumber: Int) {
+        let pageCount = mainPDFViewModel.figureAnnotations.count
+        var foundIndex: Int? = nil
+        
+        for index in 0..<pageCount {
+            if mainPDFViewModel.figureAnnotations[index].page == pageNumber {
+                foundIndex = index
+                break
+            }
         }
-      }
+        
+        if let index = foundIndex {
+            scrollToIndex = index + 1
+        } else {
+            for index in 0..<pageCount {
+                if mainPDFViewModel.figureAnnotations[index].page > pageNumber {
+                    scrollToIndex = index
+                    break
+                }
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
## 변경 사항
#### MainPDFView에서 SplitView를 띄울 때, MainView를 새로고침하는 것이 아닌 FloatingSplitView를 새로고침하도록 수정하였습니다! 🥳
FloatingSplitView를 부르는 코드가 MainView(OriginalView/ConcentrateView)를 부르는 코드보다 더 길 뿐만 아니라 세로 모드를 함께 고려하다 보니 MainPDFView의 코드가 복잡해질 수 있기에 `ViewBuilder`로 따로 분리하였습니당.

#### FigureView에서 Figure가 없을 때에도 비어있는 CustomList가 하단 영역을 차지하도록 구현되어 있어, if-else 구문을 조정하였습니다!
``` Swift
if mainPDFViewModel.figureAnnotations.isEmpty {
    Text("Fig와 Table이 있으면,\n여기에 표시됩니다")
        .reazyFont(.body3)
        .foregroundStyle(.gray600)
} else {
            ... 생략 ...
}
```

## 팀원에게 전달할 사항(Optional)
> PDF에 페이지 정보가 없는 경우가 있나요?... 페이지 정보가 없으면 앱이 냅다 튕깁니다 혹시 몰라 예외처리를 하는 것도 좋아보여용~

<img src="https://github.com/user-attachments/assets/29f1e8b4-195b-45f2-be69-0a9d64176fae" width=450/>

close #106 