### PR TITLE
[Fix] Core Data Service 패턴 수정

### DIFF
--- a/Project/Reazy/Data/DTO/CommentData+CoreDataClass.swift
+++ b/Project/Reazy/Data/DTO/CommentData+CoreDataClass.swift
@@ -1,0 +1,14 @@
+//
+//  CommentData+CoreDataClass.swift
+//  Reazy
+//
+//  Created by 유지수 on 11/7/24.
+//
+
+import Foundation
+import CoreData
+
+@objc(CommentData)
+public class CommentData: NSManagedObject {
+    
+}

--- a/Project/Reazy/Data/DTO/CommentData+CoreDataProperties.swift
+++ b/Project/Reazy/Data/DTO/CommentData+CoreDataProperties.swift
@@ -1,0 +1,26 @@
+//
+//  CommentData+CoreDataProperties.swift
+//  Reazy
+//
+//  Created by 유지수 on 11/7/24.
+//
+
+import Foundation
+import CoreData
+
+extension CommentData {
+    
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<CommentData> {
+        return NSFetchRequest<CommentData>(entityName: "CommentData")
+    }
+    
+    @NSManaged public var id: UUID?
+    @NSManaged public var buttonID: String
+    @NSManaged public var pageIndex: Int32
+    @NSManaged public var startIndex: Int32
+    @NSManaged public var length: Int32
+    @NSManaged public var text: String?
+    @NSManaged public var selectedLine: Data?
+    
+    @NSManaged public var paperData: PaperData?
+}

--- a/Project/Reazy/Data/DTO/PaperData+CoreDataProperties.swift
+++ b/Project/Reazy/Data/DTO/PaperData+CoreDataProperties.swift
@@ -26,4 +26,5 @@ extension PaperData {
     @NSManaged public var isFavorite: Bool
     
     @NSManaged public var drawingData: Set<DrawingData>?
+    @NSManaged public var commentData: Set<CommentData>?
 }

--- a/Project/Reazy/Data/Reazy.xcdatamodeld/Reazy.xcdatamodel/contents
+++ b/Project/Reazy/Data/Reazy.xcdatamodeld/Reazy.xcdatamodel/contents
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="24B83" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="CommentData" representedClassName="CommentData" syncable="YES">
+        <attribute name="buttonID" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="length" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="pageIndex" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="selectedLine" optional="YES" attributeType="Binary"/>
+        <attribute name="startIndex" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <relationship name="paperData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PaperData" inverseName="commentData" inverseEntity="PaperData"/>
+    </entity>
     <entity name="DrawingData" representedClassName="DrawingData" syncable="YES">
         <attribute name="color" optional="YES" attributeType="Binary"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
@@ -19,6 +29,7 @@
         <attribute name="thumbnail" optional="YES" attributeType="Binary"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <attribute name="url" optional="YES" attributeType="Binary"/>
+        <relationship name="commentData" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CommentData" inverseName="paperData" inverseEntity="CommentData"/>
         <relationship name="drawingData" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DrawingData" inverseName="paperData" inverseEntity="DrawingData"/>
     </entity>
 </model>

--- a/Project/Reazy/Data/Services/CommentDataService.swift
+++ b/Project/Reazy/Data/Services/CommentDataService.swift
@@ -1,0 +1,179 @@
+//
+//  CommentDataService.swift
+//  Reazy
+//
+//  Created by 유지수 on 11/7/24.
+//
+
+import Foundation
+import CoreData
+import PDFKit
+import UIKit
+
+class CommentDataService: CommentDataInterface {
+    static let shared = CommentDataService()
+    
+    private let container: NSPersistentContainer
+    
+    private init() {
+        container = NSPersistentContainer(name: "Reazy")
+        container.loadPersistentStores { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+    }
+    
+    func loadCommentData(for pdfID: UUID, pdfURL: Data) -> Result<[Comment], Error> {
+        let dataContext = container.viewContext
+        let fetchRequest: NSFetchRequest<CommentData> = CommentData.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "paperData.id == %@", pdfID as CVarArg)
+        
+        do {
+            let fetchComments = try dataContext.fetch(fetchRequest)
+            let comments = fetchComments.compactMap { commentData -> Comment in
+                
+                var isStale = false
+                var document: PDFDocument?
+                var selection: PDFSelection?
+                
+                if let url = try? URL.init(resolvingBookmarkData: pdfURL, bookmarkDataIsStale: &isStale),
+                url.startAccessingSecurityScopedResource() {
+                    document = PDFDocument(url: url)
+                    url.stopAccessingSecurityScopedResource()
+                }
+                
+                if let document = document {
+                    let pageIndex = Int(commentData.pageIndex)
+                    let firstPage = document.page(at: pageIndex)
+                    print("commentData.pageIndex = \(commentData.pageIndex)")
+                    print("commentData.text = \(String(describing: commentData.text))")
+                    
+                    selection = firstPage?.selection(for: NSRange(location: Int(commentData.startIndex), length: Int(commentData.length)))
+                }
+                
+                let selectedLine: CGRect = {
+                    if let rectData = commentData.selectedLine,
+                       let unarchiveValue = try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSValue.self, from: rectData) {
+                        return unarchiveValue.cgRectValue
+                    }
+                    return .zero
+                }()
+                
+                return Comment(
+                    id: commentData.id ?? UUID(),
+                    buttonID: commentData.buttonID,
+                    selection: selection ?? PDFSelection(),
+                    text: commentData.text ?? "",
+                    selectedLine: selectedLine
+                )
+            }
+            return .success(comments)
+        } catch {
+            return .failure(error)
+        }
+    }
+    
+    func saveCommentData(for pdfID: UUID, with comment: Comment) -> Result<VoidResponse, Error> {
+        let dataContext = container.viewContext
+        let fetchRequest: NSFetchRequest<PaperData> = PaperData.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", pdfID as CVarArg)
+        
+        do {
+            if let paperData = try dataContext.fetch(fetchRequest).first {
+                
+                let newComment = CommentData(context: dataContext)
+                
+                newComment.id = comment.id
+                newComment.buttonID = comment.buttonID
+                print("comment.pageIndex = \(String(describing: comment.selection.pages.first?.index))")
+                print("comment.buttonID = \(comment.buttonID)")
+                
+                if let firstPage = comment.selection.pages.first,
+                   let document = firstPage.document {
+                    let pageIndex = document.index(for: firstPage)
+                    newComment.pageIndex = Int32(pageIndex)
+                    
+                    let range = comment.selection.range(at: 0, on: firstPage)
+                    newComment.startIndex = Int32(range.location)
+                    newComment.length = Int32(range.length)
+                }
+                
+                newComment.text = comment.text
+                
+                if let selectedLine = try? NSKeyedArchiver.archivedData(withRootObject: NSValue(cgRect: comment.selectedLine), requiringSecureCoding: false) {
+                    newComment.selectedLine = selectedLine
+                }
+                
+                newComment.paperData = paperData
+                
+                do {
+                    try dataContext.save()
+                    return .success(VoidResponse())
+                } catch {
+                    return .failure(error)
+                }
+            } else {
+                return .failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "CommentData not found"]))
+            }
+        } catch {
+            return .failure(error)
+        }
+    }
+    
+    func editCommentData(for pdfID: UUID, with comment: Comment) -> Result<VoidResponse, Error> {
+        let dataContext = container.viewContext
+        let fetchRequest: NSFetchRequest<CommentData> = CommentData.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "paperData.id == %@ AND id == %@", pdfID as CVarArg, comment.id as CVarArg)
+        
+        do {
+            let results = try dataContext.fetch(fetchRequest)
+            if let commentToEdit = results.first {
+                
+                commentToEdit.text = comment.text
+                
+                if let firstPage = comment.selection.pages.first,
+                   let document = firstPage.document {
+                    let pageIndex = document.index(for: firstPage)
+                    commentToEdit.pageIndex = Int32(pageIndex)
+                    
+                    let range = comment.selection.range(at: 0, on: firstPage)
+                    commentToEdit.startIndex = Int32(range.location)
+                    commentToEdit.length = Int32(range.length)
+                }
+                
+                commentToEdit.text = comment.text
+                
+                if let selectedLine = try? NSKeyedArchiver.archivedData(withRootObject: NSValue(cgRect: comment.selectedLine), requiringSecureCoding: false) {
+                    commentToEdit.selectedLine = selectedLine
+                }
+                
+                try dataContext.save()
+                return .success(VoidResponse())
+            } else {
+                return .failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Comment not found"]))
+            }
+        } catch {
+            return .failure(error)
+        }
+    }
+    
+    func deleteCommentData(for pdfID: UUID, id: UUID) -> Result<VoidResponse, Error> {
+        let dataContext = container.viewContext
+        let fetchRequest: NSFetchRequest<CommentData> = CommentData.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "paperData.id == %@ AND id == %@", pdfID as CVarArg, id as CVarArg)
+        
+        do {
+            let result = try dataContext.fetch(fetchRequest)
+            if let commentToDelete = result.first {
+                dataContext.delete(commentToDelete)
+                try dataContext.save()
+                return .success(VoidResponse())
+            } else {
+                return .failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Comment not found"]))
+            }
+        } catch {
+            return .failure(error)
+        }
+    }
+}

--- a/Project/Reazy/Data/Services/DrawingDataService.swift
+++ b/Project/Reazy/Data/Services/DrawingDataService.swift
@@ -10,9 +10,11 @@ import CoreData
 import UIKit
 
 class DrawingDataService: DrawingDataInterface {
+    static let shared = DrawingDataService()
+    
     private let container: NSPersistentContainer
     
-    init() {
+    private init() {
         container = NSPersistentContainer(name: "Reazy")
         container.loadPersistentStores { (storeDescription, error) in
             if let error = error as NSError? {

--- a/Project/Reazy/Data/Services/PaperDataService.swift
+++ b/Project/Reazy/Data/Services/PaperDataService.swift
@@ -10,9 +10,11 @@ import CoreData
 import UIKit
 
 class PaperDataService: PaperDataInterface {
+    static let shared = PaperDataService()
+    
     private let container: NSPersistentContainer
     
-    init() {
+    private init() {
         container = NSPersistentContainer(name: "Reazy")
         container.loadPersistentStores { (storeDescription, error) in
             if let error = error as NSError? {

--- a/Project/Reazy/Domain/Helpers/Navigation/NavigationCoordinator.swift
+++ b/Project/Reazy/Domain/Helpers/Navigation/NavigationCoordinator.swift
@@ -50,7 +50,7 @@ final class NavigationCoordinator: CoordinatorProtocol {
         case .home:
             HomeView()
         case .mainPDF(let paperInfo):
-            MainPDFView(mainPDFViewModel: .init(paperInfo: paperInfo))
+            MainPDFView(mainPDFViewModel: .init(paperInfo: paperInfo), commentViewModel: .init(commentService: CommentDataService.shared, paperInfo: paperInfo))
         }
     }
     

--- a/Project/Reazy/Domain/Interface/CommentDataInterface.swift
+++ b/Project/Reazy/Domain/Interface/CommentDataInterface.swift
@@ -1,0 +1,19 @@
+//
+//  CommentDataInterface.swift
+//  Reazy
+//
+//  Created by 유지수 on 11/7/24.
+//
+
+import Foundation
+
+protocol CommentDataInterface {
+    /// 코멘트 기록을 불러옵니다
+    func loadCommentData(for pdfID: UUID, pdfURL: Data) -> Result<[Comment], Error>
+    /// 코멘트 기록을 저장합니다
+    func saveCommentData(for pdfID: UUID, with comment: Comment) -> Result<VoidResponse, Error>
+    /// 코멘트 기록을 수정합니다
+    func editCommentData(for pdfID: UUID, with comment: Comment) -> Result<VoidResponse, Error>
+    /// 코멘트 기록을 삭제합니다
+    func deleteCommentData(for pdfID: UUID, id: UUID) -> Result<VoidResponse, Error>
+}

--- a/Project/Reazy/Domain/Models/Comment.swift
+++ b/Project/Reazy/Domain/Models/Comment.swift
@@ -9,8 +9,8 @@ import Foundation
 import PDFKit
 
 struct Comment: Identifiable {
-    let id : UUID = .init()
-    let ButtonID: String
+    let id : UUID
+    let buttonID: String
     var selection: PDFSelection
     var text: String
     var selectedLine: CGRect

--- a/Project/Reazy/Views/Home/HomeView.swift
+++ b/Project/Reazy/Views/Home/HomeView.swift
@@ -16,7 +16,7 @@ enum Options {
 struct HomeView: View {
     @EnvironmentObject var navigationCoordinator: NavigationCoordinator
     
-    @StateObject private var pdfFileManager: PDFFileManager = .init(paperService: PaperDataService())
+    @StateObject private var pdfFileManager: PDFFileManager = .init(paperService: PaperDataService.shared)
     
     @State var selectedMenu: Options = .main
     @State var selectedPaperID: UUID?

--- a/Project/Reazy/Views/Home/Paper/PaperListView.swift
+++ b/Project/Reazy/Views/Home/Paper/PaperListView.swift
@@ -277,7 +277,7 @@ extension PaperListView {
 
 
 #Preview {
-    let manager = PDFFileManager(paperService: PaperDataService())
+    let manager = PDFFileManager(paperService: PaperDataService.shared)
     
     PaperListView(
         selectedPaperID: .constant(nil),

--- a/Project/Reazy/Views/PDF/MainPDFView.swift
+++ b/Project/Reazy/Views/PDF/MainPDFView.swift
@@ -16,8 +16,10 @@ struct MainPDFView: View {
     
     @EnvironmentObject var navigationCoordinator: NavigationCoordinator
     
+    
     @StateObject public var mainPDFViewModel: MainPDFViewModel
     @StateObject private var floatingViewModel: FloatingViewModel = .init()
+    @StateObject public var commentViewModel: CommentViewModel
     
     @State private var selectedButton: WriteButton? = nil
     @State private var selectedColor: HighlightColors = .yellow
@@ -33,7 +35,6 @@ struct MainPDFView: View {
     @State private var isFigSelected: Bool = false
     @State private var isSearchSelected: Bool = false
     @State private var isVertical = false
-    
     
     var body: some View {
         GeometryReader { geometry in
@@ -311,9 +312,10 @@ struct MainPDFView: View {
     private func mainView(for mode: String) -> some View {
         if mode == "원문 모드" {
             ZStack {
-                OriginalView(commentViewModel: .init(pdfID: mainPDFViewModel.paperInfo.id))
+                OriginalView()
                     .environmentObject(mainPDFViewModel)
                     .environmentObject(floatingViewModel)
+                    .environmentObject(commentViewModel)
                 // 18 미만 버전에서 번역 모드 on 일 때 말풍선 띄우기
                 if #unavailable(iOS 18.0) {
                     if mainPDFViewModel.toolMode == .translate {

--- a/Project/Reazy/Views/PDF/PDFViewer/OriginalView.swift
+++ b/Project/Reazy/Views/PDF/PDFViewer/OriginalView.swift
@@ -12,7 +12,7 @@ import PDFKit
 struct OriginalView: View {
     @EnvironmentObject private var viewModel: MainPDFViewModel
     @EnvironmentObject private var floatingViewModel: FloatingViewModel
-    @StateObject var commentViewModel: CommentViewModel
+    @EnvironmentObject var commentViewModel: CommentViewModel
     
     @State private var keyboardHeight: CGFloat = 0
     let publisher = NotificationCenter.default.publisher(for: .isCommentTapped)

--- a/Project/Reazy/Views/PDF/PDFViewer/VC/OriginalViewController.swift
+++ b/Project/Reazy/Views/PDF/PDFViewer/VC/OriginalViewController.swift
@@ -98,7 +98,7 @@ final class OriginalViewController: UIViewController {
             print("found annotation")
             
             if let buttonID = tappedAnnotation.contents,
-               let tappedComment = commentViewModel.comments.first(where: { $0.ButtonID == buttonID }) {
+               let tappedComment = commentViewModel.comments.first(where: { $0.buttonID == buttonID }) {
                 
                 print(tappedComment)
                 viewModel.isCommentTapped.toggle()

--- a/Project/Reazy/Views/PDF/PDFViewer/ViewModels/CommentViewModel.swift
+++ b/Project/Reazy/Views/PDF/PDFViewer/ViewModels/CommentViewModel.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 class CommentViewModel: ObservableObject {
     @Published var comments: [Comment] = []
+    private var commentService: CommentDataService
     
     // pdf 관련
     @Published var pdfConvertedBounds: CGRect = .zero
@@ -18,17 +19,31 @@ class CommentViewModel: ObservableObject {
     
     var commentPosition: CGPoint = .zero        /// 저장된 commentPosition
     var commentGroup: [Comment] = []
-    let pdfID: UUID
     
-    init(pdfID: UUID) {
-        self.pdfID = pdfID
+    public var paperInfo: PaperInfo
+    
+    init(
+        commentService: CommentDataService,
+        paperInfo: PaperInfo
+    ) {
+        self.commentService = commentService
+        self.paperInfo = paperInfo
+        
+        // MARK: - 기존에 저장된 데이터가 있다면 모델에 저장된 데이터를 추가
+        switch commentService.loadCommentData(for: paperInfo.id, pdfURL: paperInfo.url) {
+        case .success(let commentList):
+            commentGroup = commentList
+        case .failure(_):
+            return
+        }
     }
     
     // 코멘트 추가
     func addComment(text: String, selection: PDFSelection) {
         
         let selectedLine = getSelectedLine(selection: selection)
-        let newComment = Comment(ButtonID: "\(selectedLine)", selection: selection, text: text, selectedLine: selectedLine)
+        let newComment = Comment(id: UUID(), buttonID: "\(selectedLine)", selection: selection, text: text, selectedLine: selectedLine)
+        _ = commentService.saveCommentData(for: paperInfo.id, with: newComment)
         comments.append(newComment)
         addCommentIcon(selection: selection, newComment: newComment)
         drawUnderline(selection: selection, newComment: newComment)
@@ -36,6 +51,7 @@ class CommentViewModel: ObservableObject {
     
     // 코멘트 삭제
     func deleteComment(selection: PDFSelection, comment: Comment) {
+        _ = commentService.deleteCommentData(for: paperInfo.id, id: comment.id)
         comments.removeAll(where: { $0.id == comment.id })
         removeAnnotations(comment: comment)
     }
@@ -93,7 +109,7 @@ extension CommentViewModel {
     }
     
     func findCommentGroup(tappedComment: Comment) {
-        let group = comments.filter { $0.ButtonID == tappedComment.ButtonID }
+        let group = comments.filter { $0.buttonID == tappedComment.buttonID }
         self.commentGroup = group
     }
 }
@@ -128,7 +144,7 @@ extension CommentViewModel {
         commentIcon.widgetControlType = .pushButtonControl
         
         /// 버튼에 코멘트 정보 참조
-        commentIcon.setValue(newComment.ButtonID, forAnnotationKey: .contents)
+        commentIcon.setValue(newComment.buttonID, forAnnotationKey: .contents)
         page.addAnnotation(commentIcon)
     }
     
@@ -163,7 +179,7 @@ extension CommentViewModel {
                 if let annotationID = annotation.value(forAnnotationKey: .contents) as? String{
                     
                     if commentGroup.count == 1 {
-                        if annotationID == comment.ButtonID || annotationID == comment.id.uuidString {
+                        if annotationID == comment.buttonID || annotationID == comment.id.uuidString {
                             page.removeAnnotation(annotation)
                         }
                     } else if commentGroup.count > 1, annotationID == comment.id.uuidString {

--- a/Project/Reazy/Views/PDF/PDFViewer/ViewModels/MainPDFViewModel.swift
+++ b/Project/Reazy/Views/PDF/PDFViewer/ViewModels/MainPDFViewModel.swift
@@ -89,7 +89,7 @@ final class MainPDFViewModel: ObservableObject {
             url.stopAccessingSecurityScopedResource()
         }
         
-        self.pdfDrawer = .init(drawingService: DrawingDataService(), pdfID: paperInfo.id)
+        self.pdfDrawer = .init(drawingService: DrawingDataService.shared, pdfID: paperInfo.id)
         
     }
 }
@@ -363,7 +363,7 @@ extension MainPDFViewModel {
                     highlight.color = UIColor.comment
                     
                     /// 하이라이트 주석 구별하기
-                    highlight.setValue("\(comment.ButtonID) isHighlight", forAnnotationKey: .contents)
+                    highlight.setValue("\(comment.buttonID) isHighlight", forAnnotationKey: .contents)
                     page.addAnnotation(highlight)
                 }
             }
@@ -372,7 +372,7 @@ extension MainPDFViewModel {
                 for annotation in page.annotations {
                     /// 하이라이트 주석만 제거
                     if let annotationValue = annotation.value(forAnnotationKey: .contents) as? String,
-                       annotationValue == "\(comment.ButtonID) isHighlight" {
+                       annotationValue == "\(comment.buttonID) isHighlight" {
                         page.removeAnnotation(annotation)
                     }
                 }


### PR DESCRIPTION
## 변경 사항
- [ ] 세 가지 Data Service의 패턴을 싱글톤으로 수정하였습니다
기존 방식의 경우 `container`를 서비스마다 만들게 되어 중복의 확률이 높아집니다!
그래서 세 개의 서비스를 모두 싱글톤 패턴으로 수정했어용.
- [ ] 그 외에 변수명 대문자 > 소문자 변경 등 사소한 작업을 수행했습니당.

## 팀원에게 전달할 사항(Optional)
![image](https://github.com/user-attachments/assets/8de3646e-6ded-40c1-a2e0-3231b770fdf8)

close #149 
