### PR TITLE
[Fix] 지우개 감도 조정, 하이라이트 드로잉에만 지우게 수정

### DIFF
--- a/Project/Reazy/Views/PDF/Drawing/PDFDrawer.swift
+++ b/Project/Reazy/Views/PDF/Drawing/PDFDrawer.swift
@@ -240,7 +240,7 @@ extension PDFDrawer: DrawingGestureRecognizerDelegate {
         if let pageIndex = pdfView.document?.index(for: page) {
             for annotation in annotations {
                 // 하이라이트랑 드로잉만 지우기
-                if annotation.type == "Ink" || annotation.type == "Highlight" {
+                if annotation.type == "Ink" || (annotation.type == "Highlight" && annotation.value(forAnnotationKey: .contents) == nil) {
                     let annotationBounds = annotation.bounds
                     
                     let indicesToRemove = drawingDataArray.indices.filter { index in


### PR DESCRIPTION
## 변경 사항
- [ ] pdf 확대 축소 시 펜 터치 영역에 들어가는 원 사이즈를 비율에 맞게 조정해 실제 지워지는 영역과 싱크를 맞췄습니다
- [ ] 기존 코멘트까지 지우는 만능 지우개에서 하이라이트 드로잉만 지워지게 수정하였습니다
- [ ] 설명 용 주석 추가


## 스크린샷 or 영상 링크
| 하이라이트 드로잉 지우고 코멘트 안지워지고, 확대하면 비율에 맞게 지우개 모양 달라지는 영상

https://github.com/user-attachments/assets/b557f398-16c0-4e5b-a012-63f42265d031

## 팀원에게 전달할 사항(Optional)
|

![image](https://github.com/user-attachments/assets/901ef98b-5b22-4db8-92a7-aa99cb46788c)


#144 