### PR TITLE
[Feat] Figure 관련 Core Data CRUD 구현

### DIFF
--- a/Project/Reazy/Data/DTO/FigureData+CoreDataClass.swift
+++ b/Project/Reazy/Data/DTO/FigureData+CoreDataClass.swift
@@ -1,0 +1,14 @@
+//
+//  FigureData+CoreDataClass.swift
+//  Reazy
+//
+//  Created by 유지수 on 11/10/24.
+//
+
+import Foundation
+import CoreData
+
+@objc(FigureData)
+public class FigureData: NSManagedObject {
+    
+}

--- a/Project/Reazy/Data/DTO/FigureData+CoreDataProperties.swift
+++ b/Project/Reazy/Data/DTO/FigureData+CoreDataProperties.swift
@@ -1,0 +1,25 @@
+//
+//  FigureData+CoreDataProperties.swift
+//  Reazy
+//
+//  Created by 유지수 on 11/10/24.
+//
+
+import Foundation
+import CoreData
+
+extension FigureData {
+    
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<FigureData> {
+        return NSFetchRequest<FigureData>(entityName: "FigureData")
+    }
+    
+    @NSManaged public var id: String
+    @NSManaged public var head: String?
+    @NSManaged public var label: String?
+    @NSManaged public var figDesc: String?
+    @NSManaged public var coords: [String]
+    @NSManaged public var graphiCoord: [String]?
+    
+    @NSManaged public var paperData: PaperData?
+}

--- a/Project/Reazy/Data/DTO/PaperData+CoreDataProperties.swift
+++ b/Project/Reazy/Data/DTO/PaperData+CoreDataProperties.swift
@@ -25,4 +25,5 @@ extension PaperData {
     
     @NSManaged public var drawingData: Set<DrawingData>?
     @NSManaged public var commentData: Set<CommentData>?
+    @NSManaged public var figureData: Set<FigureData>?
 }

--- a/Project/Reazy/Data/Reazy.xcdatamodeld/Reazy.xcdatamodel/contents
+++ b/Project/Reazy/Data/Reazy.xcdatamodeld/Reazy.xcdatamodel/contents
@@ -17,6 +17,15 @@
         <attribute name="path" optional="YES" attributeType="Binary"/>
         <relationship name="paperData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PaperData" inverseName="drawingData" inverseEntity="PaperData"/>
     </entity>
+    <entity name="FigureData" representedClassName="FigureData" syncable="YES">
+        <attribute name="coords" optional="YES" attributeType="Transformable"/>
+        <attribute name="figDesc" optional="YES" attributeType="String"/>
+        <attribute name="graphicCoord" optional="YES" attributeType="Transformable"/>
+        <attribute name="head" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
+        <relationship name="paperData" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PaperData" inverseName="figureData" inverseEntity="PaperData"/>
+    </entity>
     <entity name="PaperData" representedClassName="PaperData" syncable="YES">
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isFavorite" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
@@ -28,5 +37,6 @@
         <attribute name="url" optional="YES" attributeType="Binary"/>
         <relationship name="commentData" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CommentData" inverseName="paperData" inverseEntity="CommentData"/>
         <relationship name="drawingData" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DrawingData" inverseName="paperData" inverseEntity="DrawingData"/>
+        <relationship name="figureData" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="FigureData" inverseName="paperData" inverseEntity="FigureData"/>
     </entity>
 </model>

--- a/Project/Reazy/Data/Services/CommentDataService.swift
+++ b/Project/Reazy/Data/Services/CommentDataService.swift
@@ -127,8 +127,8 @@ class CommentDataService: CommentDataInterface {
         fetchRequest.predicate = NSPredicate(format: "paperData.id == %@ AND id == %@", pdfID as CVarArg, comment.id as CVarArg)
         
         do {
-            let results = try dataContext.fetch(fetchRequest)
-            if let commentToEdit = results.first {
+            let result = try dataContext.fetch(fetchRequest)
+            if let commentToEdit = result.first {
                 
                 commentToEdit.text = comment.text
                 

--- a/Project/Reazy/Data/Services/FigureDataService.swift
+++ b/Project/Reazy/Data/Services/FigureDataService.swift
@@ -1,0 +1,127 @@
+//
+//  FigureDataService.swift
+//  Reazy
+//
+//  Created by 유지수 on 11/10/24.
+//
+
+import Foundation
+import CoreData
+import UIKit
+
+class FigureDataService: FigureDataInterface {
+    static let shared = FigureDataService()
+    
+    private let container: NSPersistentContainer
+    
+    private init() {
+        container = NSPersistentContainer(name: "Reazy")
+        container.loadPersistentStores {
+            (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+    }
+    
+    func loadFigureData(for pdfID: UUID) -> Result<[Figure], any Error> {
+        let dataContext = container.viewContext
+        let fetchRequest: NSFetchRequest<FigureData> = FigureData.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "paperData.id == %@", pdfID as CVarArg)
+        
+        do {
+            let fetchedFigures = try dataContext.fetch(fetchRequest)
+            let figures = fetchedFigures.map { figureData -> Figure in
+                
+                return Figure(
+                    id: figureData.id,
+                    head: figureData.head,
+                    label: figureData.label,
+                    figDesc: figureData.figDesc,
+                    coords: figureData.coords,
+                    graphicCoord: figureData.graphiCoord
+                )
+            }
+            return .success(figures)
+        } catch {
+            return .failure(error)
+        }
+    }
+    
+    func saveFigureData(for pdfID: UUID, with figure: Figure) -> Result<VoidResponse, any Error> {
+        let dataContext = container.viewContext
+        let fetchRequest: NSFetchRequest<PaperData> = PaperData.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %@", pdfID as CVarArg)
+        
+        do {
+            if let paperData = try dataContext.fetch(fetchRequest).first {
+                
+                let newFigureData = FigureData(context: dataContext)
+                
+                newFigureData.id = figure.id
+                newFigureData.head = figure.head
+                newFigureData.label = figure.label
+                newFigureData.figDesc = figure.figDesc
+                newFigureData.coords = figure.coords
+                newFigureData.graphiCoord = figure.graphicCoord
+                
+                newFigureData.paperData = paperData
+                
+                do {
+                    try dataContext.save()
+                    return .success(VoidResponse())
+                } catch {
+                    return .failure(error)
+                }
+            } else {
+                return .failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "FigureData not found"]))
+            }
+        } catch {
+            return .failure(error)
+        }
+    }
+    
+    func editFigureData(for pdfID: UUID, with figure: Figure) -> Result<VoidResponse, any Error> {
+        let dataContext = container.viewContext
+        let fetchRequest: NSFetchRequest<FigureData> = FigureData.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "paperData.id == %@ AND id == %@", pdfID as CVarArg, figure.id as CVarArg)
+        
+        do {
+            let result = try dataContext.fetch(fetchRequest)
+            if let figureToEdit = result.first {
+                
+                figureToEdit.head = figure.head
+                figureToEdit.label = figure.label
+                figureToEdit.figDesc = figure.figDesc
+                figureToEdit.coords = figure.coords
+                figureToEdit.graphiCoord = figure.graphicCoord
+                
+                try dataContext.save()
+                return .success(VoidResponse())
+            } else {
+                return .failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Figure not found"]))
+            }
+        } catch {
+            return .failure(error)
+        }
+    }
+    
+    func deleteFigureData(for pdfID: UUID, id: String) -> Result<VoidResponse, any Error> {
+        let dataContext = container.viewContext
+        let fetchRequest: NSFetchRequest<FigureData> = FigureData.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "paperData.id == %@ AND id == %@", pdfID as CVarArg, id as CVarArg)
+        
+        do {
+            let result = try dataContext.fetch(fetchRequest)
+            if let figureToDelete = result.first {
+                dataContext.delete(figureToDelete)
+                try dataContext.save()
+                return .success(VoidResponse())
+            } else {
+                return .failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Figure not found"]))
+            }
+        } catch {
+            return .failure(error)
+        }
+    }
+}

--- a/Project/Reazy/Domain/Interface/FigureDataInterface.swift
+++ b/Project/Reazy/Domain/Interface/FigureDataInterface.swift
@@ -1,0 +1,19 @@
+//
+//  FigureDataInterface.swift
+//  Reazy
+//
+//  Created by 유지수 on 11/10/24.
+//
+
+import Foundation
+
+protocol FigureDataInterface {
+    /// 저장된 FigureData를 불러옵니다
+    func loadFigureData(for pdfID: UUID) -> Result<[Figure], Error>
+    /// FigureData를 저장합니다
+    func saveFigureData(for pdfID: UUID, with figure: Figure) -> Result<VoidResponse, Error>
+    /// FigureData를 수정합니다
+    func editFigureData(for pdfID: UUID, with figure: Figure) -> Result<VoidResponse, Error>
+    /// FigureData를 삭제합니다
+    func deleteFigureData(for pdfID: UUID, id: String) -> Result<VoidResponse, Error>
+}

--- a/Project/Reazy/Domain/Models/PDFLayout.swift
+++ b/Project/Reazy/Domain/Models/PDFLayout.swift
@@ -14,13 +14,13 @@ import Foundation
 struct PDFLayout: Codable {
     let fig: [Figure]
     let table: [Figure]?
-    
-    struct Figure: Codable {
-        let id: String
-        let head: String?
-        let label: String?
-        let figDesc: String?
-        let coords: [String]
-        let graphicCoord: [String]?
-    }
+}
+
+struct Figure: Codable {
+    let id: String
+    let head: String?
+    let label: String?
+    let figDesc: String?
+    let coords: [String]
+    let graphicCoord: [String]?
 }


### PR DESCRIPTION
## 변경 사항
- [ ] Core Data `FigureData` Entity 생성
- [ ] `FigureDataInterface` 생성
- [ ] `FigureDataService` 구성
- [ ] `Figure` 구조체 외부로 분리

## 팀원에게 전달할 사항(Optional)
> **[무니]**
제가 보통 초기 코드를 잡아두는데 Figure는 초기 코드 위치를 잘 모르겠어서, 아래에 추가 방법을 기재해 놓겠지만 혹시 추가가 어려우시다면 TODO - [브리]로 위치 한 번만 잡아주시면 제가 바로 추가하겠습니당!

#### ✨ FigureService가 필요한 위치에 다음과 같이 service를 초기화해 주세요!
``` Swift
private var figureService: FigureDataService
    
    init(
        figureService: FigureDataService
    ) {
        self.figureService = figureService
        // MARK: - 기존에 저장된 데이터가 있다면 모델에 저장된 데이터를 추가
        switch figureService.loadFigureData() {
        case .success(let figureList):
            // 상단에 var figures: [Figure] = [] 등의 코드가 있다고 가정
            figures = figureList
        case .failure(_):
            return
        }
    }
```

#### ✨ 실제로 사용하실 때는 아래처럼 사용해 주시면 됩니다! (이미 알 것 같지만...)
``` Swift
_ = figureService.saveFigureData(figures)
```

궁금한 사항이 있으시다면 꼭 연락주시조.

<img src="https://github.com/user-attachments/assets/085195c2-41a7-4424-a6c1-249c9aa6968d" width=450/>

close #163 
