### PR TITLE
[Fix] 메모리 관리

### DIFF
--- a/Project/Reazy/Views/PDF/Menu/TableList/VC/ThumbnailTableViewController.swift
+++ b/Project/Reazy/Views/PDF/Menu/TableList/VC/ThumbnailTableViewController.swift
@@ -44,6 +44,10 @@ final class ThumbnailTableViewController: UIViewController {
         setUI()
         setBinding()
     }
+    
+    deinit {
+        self.cancellables.forEach { $0.cancel() }
+    }
 }
 
 // MARK: - UI 초기 설정
@@ -67,11 +71,15 @@ extension ThumbnailTableViewController {
             }
             .store(in: &self.cancellables)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(redrawScreen), name: UIDevice.orientationDidChangeNotification, object: nil)
+        NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)
+            .sink { [weak self] _ in
+                self?.redrawScreen()
+            }
+            .store(in: &self.cancellables)
     }
     
 
-    @objc private func redrawScreen() {
+    private func redrawScreen() {
         self.thumbnailTableView.reloadData()
     }
 }

--- a/Project/Reazy/Views/PDF/PDFViewer/OriginalView.swift
+++ b/Project/Reazy/Views/PDF/PDFViewer/OriginalView.swift
@@ -16,6 +16,7 @@ struct OriginalView: View {
     @EnvironmentObject var commentViewModel: CommentViewModel
     
     @State private var keyboardOffset: CGFloat = 0
+    @State private var cancellables: Set<AnyCancellable> = []
     
     private let publisher = NotificationCenter.default.publisher(for: .isCommentTapped)
     private let screenHeight = UIScreen.main.bounds.height
@@ -60,24 +61,35 @@ struct OriginalView: View {
                 let screenHeight = geometry.size.height
                 
                 // 키보드 Notification 설정
-                NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: .main) { notification in
-                    if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
-                        withAnimation {
-                            keyboardOffset = calculateOffset(for: viewModel.commentInputPosition, keyboardFrame: keyboardFrame, screenHeight: screenHeight)
+                NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)
+                    .receive(on: DispatchQueue.main)
+                    .sink {
+                        if let keyboardFrame = $0.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                            withAnimation {
+                                keyboardOffset = calculateOffset(
+                                    for: viewModel.commentInputPosition, keyboardFrame: keyboardFrame, screenHeight: screenHeight)
+                            }
                         }
                     }
-                }
-                NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillHideNotification, object: nil, queue: .main) { _ in
-                    withAnimation {
-                        keyboardOffset = 0
+                    .store(in: &cancellables)
+                
+                NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)
+                    .receive(on: DispatchQueue.main)
+                    .sink { _ in
+                        withAnimation {
+                            keyboardOffset = 0
+                        }
                     }
-                }
+                    .store(in: &cancellables)
             }
             .animation(.smooth(duration: 0.3), value: viewModel.commentInputPosition)
             .animation(.smooth(duration: 0.1), value: viewModel.isCommentTapped)
             .transition(.move(edge: .bottom).combined(with: .opacity))
             .onChange(of: viewModel.selectedText) { _, newValue in
                 viewModel.updateBubbleView(selectedText: newValue, bubblePosition: viewModel.bubbleViewPosition)
+            }
+            .onDisappear {
+                self.cancellables.forEach { $0.cancel() }
             }
         }
     }

--- a/Project/Reazy/Views/PDF/PDFViewer/VC/ConcentrateViewController.swift
+++ b/Project/Reazy/Views/PDF/PDFViewer/VC/ConcentrateViewController.swift
@@ -57,6 +57,10 @@ final class ConcentrateViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    deinit {
+        self.cancellables.forEach { $0.cancel() }
+    }
 }
 
 // MARK: - 초기 세팅

--- a/Project/Reazy/Views/PDF/PDFViewer/VC/OriginalViewController.swift
+++ b/Project/Reazy/Views/PDF/PDFViewer/VC/OriginalViewController.swift
@@ -65,6 +65,10 @@ final class OriginalViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    deinit {
+        self.cancellable.forEach { $0.cancel() }
+    }
 }
 
 // MARK: - 초기 설정
@@ -120,7 +124,7 @@ extension OriginalViewController {
     /// 데이터 Binding
     private func setBinding() {
         // ViewModel toolMode의 변경 감지해서 pencil이랑 eraser일 때만 펜슬 제스처 인식하게
-        viewModel.$toolMode
+        self.viewModel.$toolMode
             .sink { [weak self] mode in
                 self?.updateGestureRecognizer(for: mode)
             }


### PR DESCRIPTION
## 변경 사항
- [ ] NotificationCenter -> Combine 문법으로 변환
- [ ] 객체가 해제될 때 combine이 해제되게 변경



## 팀원에게 전달할 사항(Optional)
* NotificationCenter나 Combine의 subscriber에 경우 직접 할당 해제를 하지 않으면 객체가 소멸되도 계속 구독되어 있는 형태입니다.
* 그래서 객체가 해제될 때 `close()`를 호출해주어 직접 할당을 해제해야 합니다.
* 또 다른 방법으로는 SwiftUI에 `.onRecieve()`를 사용하면 자동으로 해제가 됩니다.
* 다음부터 다들 사용하실 때 이 부분 고려하시면서 사용해 주시기 바랍니다!

close #182 

