### PR TITLE
[Fix] Dark Mode 삭제

### DIFF
--- a/Reazy.xcodeproj/project.pbxproj
+++ b/Reazy.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -421,6 +422,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## 변경 사항
- [ ] 기기 설정이 다크모드여도 디자인에 변함이 없도록 다크모드를 막고 라이트 모드와 동일한 뷰를 유지하도록 수정하였습니당

## 스크린샷 or 영상 링크
### 아래와 같이 다크모드로 설정한 뒤 앱을 실행했을 때 라이트 모드와 동일하게 보입니당 ✨
- 배경화면을 설정했음에도 불구하고 다크 모드에서 배경이 까맣게 보였던 건 `.gray100`이 아닌 `.white`로 지정했기 때문인 것 같아요!
- 나중에 언젠가 만약에 다크 모드를 따로 만들게 된다면 이 부분을 신경써야 할 것 같습니당
<img src="https://github.com/user-attachments/assets/e6c08194-fb47-4958-a9bc-5027fba095ce" width=400/>
<img src="https://github.com/user-attachments/assets/01de8d9c-8372-4dc5-b7bf-321afb4cb5a9" width=400/>

## 팀원에게 전달할 사항(Optional)
> 빨리 처리할 수 있는 건 빠르게 끝내기~! (브리가)

<img src="https://github.com/user-attachments/assets/c3a0aaeb-0dcb-4089-916d-8934dca8db3e" width=350/>

close #197 
