### PR TITLE
[Hotfix] 키보드 return 액션 추가

### DIFF
--- a/Project/Reazy/Views/Home/HomeView.swift
+++ b/Project/Reazy/Views/Home/HomeView.swift
@@ -383,12 +383,28 @@ private struct RenamePaperTitleView: View {
                     }
                     .frame(width: 400, height: isEditingTitle ? 52 : 180)
                     .overlay(alignment: isEditingTitle ? .center : .topLeading) {
-                        TextField( isEditingTitle ? "제목을 입력해주세요." : "내용을 입력해주세요.", text: $text, axis: .vertical)
-                            .lineLimit( isEditingTitle ? 1 : 6)
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, isEditingTitle ? 0 : 16)
-                            .font(.custom(ReazyFontType.pretendardMediumFont, size: 16))
-                            .foregroundStyle(.gray800)
+                        
+                        if isEditingTitle {
+                            TextField("제목을 입력해주세요.", text: $text)
+                                .submitLabel(.done)
+                                .onSubmit {
+                                    pdfFileManager.updateTitle(at: paperInfo.id, title: text)
+                                    isEditingTitle = false
+                                }
+                                .lineLimit( isEditingTitle ? 1 : 6)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, isEditingTitle ? 0 : 16)
+                                .font(.custom(ReazyFontType.pretendardMediumFont, size: 16))
+                                .foregroundStyle(.gray800)
+                        } else {
+                            TextField("내용을 입력해주세요.", text: $text, axis: .vertical)
+                                .submitLabel(.return)
+                                .lineLimit(6)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 16)
+                                .font(.custom(ReazyFontType.pretendardMediumFont, size: 16))
+                                .foregroundStyle(.gray800)
+                        }
                     }
                     .overlay(alignment: isEditingTitle ? .trailing : .bottomTrailing) {
                         if !self.text.isEmpty {


### PR DESCRIPTION
## 변경 사항
- [ ] 타이틀 수정 뷰에서 키보드의 return을 눌렀을 때 바로 저장이 되도록 수정


## 스크린샷 or 영상 링크

https://github.com/user-attachments/assets/49b7a493-7c7e-4ea5-850b-0edddad95628



close #206 

