### PR TITLE
[Hotfix] 하이라이트 시간 수정

### DIFF
--- a/Project/Reazy/Views/PDF/PDFViewer/VC/OriginalViewController.swift
+++ b/Project/Reazy/Views/PDF/PDFViewer/VC/OriginalViewController.swift
@@ -162,14 +162,18 @@ extension OriginalViewController {
         
         // 현재 드래그된 텍스트 가져오는 함수
         NotificationCenter.default.publisher(for: .PDFViewSelectionChanged)
-            .debounce(for: .milliseconds(350), scheduler: RunLoop.main)
+            .debounce(for: .milliseconds(700), scheduler: RunLoop.main)
+        
             .sink { [weak self] _ in
                 guard let self = self else { return }
+                
                 switch self.viewModel.toolMode {
+                    
                 case .highlight:
                     DispatchQueue.main.async {
                         self.viewModel.highlightText(in: self.mainPDFView, with: self.viewModel.selectedHighlightColor)              // 하이라이트 기능
                     }
+                    
                 case .translate, .comment:
                     guard let selection = self.mainPDFView.currentSelection else {
                         // 선택된 텍스트가 없을 때 특정 액션
@@ -219,6 +223,7 @@ extension OriginalViewController {
                     // 텍스트 선택 후 딜레이
                     self.selectionWorkItem = workItem
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
+                    
                 default:
                     return
                 }


### PR DESCRIPTION
## 변경 사항
- [ ] 하이라이트의 지연 시간을 0.35초 -> 0.7초로 변경하였습니다.


## 스크린샷 or 영상 링크
| 

https://github.com/user-attachments/assets/39cff6fd-a7d5-4d54-a08b-5435b06e9284



## 팀원에게 전달할 사항(Optional)
|
현재 Notificatoin에 debounce를 걸어 이벤트가 없으면 0.7초 후 실행되도록 되어 있습니다.
하지만 Notification에 하이라이트와 번역이 같이 있어서 번역도 0.7초 후에 실행됩니다.
debounce를 분리하려고 했지만 오늘까지는 되지 않을것 같아서 일단 push하고 주말동안 해보겠습니다.
