### PR TITLE
[Hotfix] 텍스트 선택시 뜨는 edit menu 설정하기

### DIFF
--- a/Project/Reazy/Views/PDF/PDFViewer/VC/OriginalViewController.swift
+++ b/Project/Reazy/Views/PDF/PDFViewer/VC/OriginalViewController.swift
@@ -339,22 +339,6 @@ extension OriginalViewController: UIGestureRecognizerDelegate {
     }
 }
 
-extension OriginalViewController: UIEditMenuInteractionDelegate {
-    
-    func editMenuInteraction(_ interaction: UIEditMenuInteraction, menuFor configuration: UIEditMenuConfiguration, suggestedActions: [UIMenuElement]) -> UIMenu? {
-        let searchWebAction = UIAction(title: "Search Web", image: nil, identifier: nil) { action in
-            // 선택한 텍스트로 Google 검색
-            if let selectedTextRange = self.mainPDFView.currentSelection?.string {
-                let query = selectedTextRange.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-                if let url = URL(string: "https://www.google.com/search?q=\(query)") {
-                    UIApplication.shared.open(url)
-                }
-            }
-        }
-        return UIMenu(children: [searchWebAction])
-    }
-}
-
 //canPerformAction()으로 menuAction 제한
 class CustomPDFView: PDFView {
     var toolMode: ToolMode = .none


### PR DESCRIPTION
## 변경 사항
- [ ] 모드에 따른 edit menu 설정
- 코멘트, 하이라이트, 번역일 때 -> 아무것도 뜨지 않게 함
- 디폴트로는 copy, search web, sahre.. 만 뜨게 함


## 스크린샷 or 영상 링크
https://github.com/user-attachments/assets/59d0093b-613f-4ae0-a359-8f4e9609982a

번역은 실 기기가 없어서.. 다른 분이 테스트 해주시면 감사하겠습니다~



## 팀원에게 전달할 사항(Optional)
`canPerformAction()`을 활용하기 위해 기존의 PDFView를 CustomPDFView로 만들어 설정해 주었습니다
Look up 메뉴의 경우 search web과 엮여 있어 look up을 삭제하면 search web도 사라지는 문제가 있더라구요
그래서 look up 삭제 후에 search web 메뉴 기능을 만들어서 따로 넣어줬습니다

close #203 
