### PR TITLE
[Fix] 하이라이트 시간지연 분리

### DIFF
--- a/Project/Reazy/Views/PDF/PDFViewer/VC/OriginalViewController.swift
+++ b/Project/Reazy/Views/PDF/PDFViewer/VC/OriginalViewController.swift
@@ -204,79 +204,77 @@ extension OriginalViewController {
             }
             .store(in: &self.cancellable)
         
-        // 현재 드래그된 텍스트 가져오는 함수
+        
+        // 하이라이트 기능 실행
         NotificationCenter.default.publisher(for: .PDFViewSelectionChanged)
             .debounce(for: .milliseconds(700), scheduler: RunLoop.main)
         
             .sink { [weak self] _ in
                 guard let self = self else { return }
                 
-                switch self.viewModel.toolMode {
-                case .drawing:
-                    switch self.viewModel.drawingToolMode {
-                    case .highlight:
-                        DispatchQueue.main.async {
-                            self.viewModel.highlightText(in: self.mainPDFView, with: self.viewModel.selectedHighlightColor)              // 하이라이트 기능
-                        }
-                    default:
-                        return
-                    }
-                    
-                case .translate, .comment:
-                    guard let selection = self.mainPDFView.currentSelection else {
-                        // 선택된 텍스트가 없을 때 특정 액션
-                        self.viewModel.selectedText = ""                                // 선택된 텍스트 초기화
-                        self.viewModel.translateViewVisible = true                        // 말풍선 뷰 숨김
-                        return
-                    }
-                    
-                    self.selectionWorkItem?.cancel()
-                    
-                    let workItem = DispatchWorkItem { [weak self] in
-                        guard let self = self else { return }
-                        if let page = selection.pages.first {
-                            
-                            // PDFSelection의 bounds 추출(CGRect)
-                            let bound = selection.bounds(for: page)
-                            let convertedBounds = self.mainPDFView.convert(bound, from: page)
-                            
-                            //comment position 설정
-                            let commentPosition = CGPoint(
-                                x: convertedBounds.midX,
-                                y: convertedBounds.maxY + 50
-                            )
-                            
-                            // 선택된 텍스트 가져오기
-                            let selectedText = selection.string ?? ""
-                            
-                            // PDFPage의 좌표를 PDFView의 좌표로 변환
-                            let pagePosition = self.mainPDFView.convert(bound, from: page)
-                            
-                            // PDFView의 좌표를 Screen의 좌표로 변환
-                            let screenPosition = self.mainPDFView.convert(pagePosition, to: nil)
-                            
-                            DispatchQueue.main.async {
-                                // ViewModel에 선택된 텍스트와 위치 업데이트
-                                self.viewModel.selectedText = selectedText
-                                self.viewModel.translateViewPosition = screenPosition              // 위치 업데이트
-                                self.viewModel.translateViewVisible = !selectedText.isEmpty        // 텍스트가 있을 때만 보여줌
-                                
-                                self.viewModel.commentSelection = selection
-                                self.viewModel.commentInputPosition = commentPosition
-                                self.commentViewModel.selectedBounds = bound
-                            }
-                        }
-                    }
-                    
-                    // 텍스트 선택 후 딜레이
-                    self.selectionWorkItem = workItem
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
-                    
-                default:
-                    return
+                DispatchQueue.main.async {
+                    self.viewModel.highlightText(in: self.mainPDFView, with: self.viewModel.selectedHighlightColor)         // 하이라이트 기능
                 }
             }
             .store(in: &self.cancellable)
+        
+        
+        // 번역 및 코멘트 기능 실행
+        NotificationCenter.default.publisher(for: .PDFViewSelectionChanged)
+            .sink { [weak self] _ in
+                guard let self = self else { return }
+                
+                guard let selection = self.mainPDFView.currentSelection else {
+                    // 선택된 텍스트가 없을 때 특정 액션
+                    self.viewModel.selectedText = ""                                                                        // 선택된 텍스트 초기화
+                    self.viewModel.translateViewVisible = true                                                              // 말풍선 뷰 숨김
+                    return
+                }
+                
+                self.selectionWorkItem?.cancel()
+                
+                let workItem = DispatchWorkItem { [weak self] in
+                    guard let self = self else { return }
+                    if let page = selection.pages.first {
+                        
+                        // PDFSelection의 bounds 추출(CGRect)
+                        let bound = selection.bounds(for: page)
+                        let convertedBounds = self.mainPDFView.convert(bound, from: page)
+                        
+                        //comment position 설정
+                        let commentPosition = CGPoint(
+                            x: convertedBounds.midX,
+                            y: convertedBounds.maxY + 50
+                        )
+                        
+                        // 선택된 텍스트 가져오기
+                        let selectedText = selection.string ?? ""
+                        
+                        // PDFPage의 좌표를 PDFView의 좌표로 변환
+                        let pagePosition = self.mainPDFView.convert(bound, from: page)
+                        
+                        // PDFView의 좌표를 Screen의 좌표로 변환
+                        let screenPosition = self.mainPDFView.convert(pagePosition, to: nil)
+                        
+                        DispatchQueue.main.async {
+                            // ViewModel에 선택된 텍스트와 위치 업데이트
+                            self.viewModel.selectedText = selectedText
+                            self.viewModel.translateViewPosition = screenPosition              // 위치 업데이트
+                            self.viewModel.translateViewVisible = !selectedText.isEmpty        // 텍스트가 있을 때만 보여줌
+                            
+                            self.viewModel.commentSelection = selection
+                            self.viewModel.commentInputPosition = commentPosition
+                            self.commentViewModel.selectedBounds = bound
+                        }
+                    }
+                }
+                
+                // 텍스트 선택 후 딜레이
+                self.selectionWorkItem = workItem
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
+            }
+            .store(in: &self.cancellable)
+        
         
         // 저장하면 currentSelection 해제
         self.viewModel.$isCommentSaved

--- a/Project/Reazy/Views/PDF/PDFViewer/ViewModels/MainPDFViewModel.swift
+++ b/Project/Reazy/Views/PDF/PDFViewer/ViewModels/MainPDFViewModel.swift
@@ -426,8 +426,9 @@ extension MainPDFViewModel {
 extension MainPDFViewModel {
     // 하이라이트 기능
     func highlightText(in pdfView: PDFView, with color: HighlightColors) {
-        // drawingToolMode가 highlight일때 동작
-        guard drawingToolMode == .highlight else { return }
+        
+        // (toolMode == .drawing && drawingToolMode == .highlight) 일때 동작
+        guard toolMode == .drawing, drawingToolMode == .highlight else { return }
 
         // PDFView 안에서 스크롤 영역 파악
         guard let currentSelection = pdfView.currentSelection else { return }
@@ -441,6 +442,7 @@ extension MainPDFViewModel {
 
         selections.forEach { selection in
             var bounds = selection.bounds(for: page)
+            
             let originBoundsHeight = bounds.size.height
             bounds.size.height *= 0.6                                                   // bounds 높이 조정하기
             bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2            // 줄인 높인만큼 y축 이동


### PR DESCRIPTION
## 변경 사항
- [x] 하이라이트와 번역 모두 시간지연이 되던걸 분리하여 하이라이트만 지연되도록 했습니다.
- [x] toolMode와 drawingToolMode 모두 눌러져야 하이라이트가 작동되도록 했습니다.


## 스크린샷 or 영상 링크
|

https://github.com/user-attachments/assets/64f21df1-cd37-4930-bf67-91dc576f37cf


## 팀원에게 전달할 사항(Optional)
|

**1. 하이라이트에만 시간지연이 되도록 분리하였습니다.**
 - NotificationCenter 내에 하이라이트와 번역 기능이 같이 있어서 두 기능 모두에 시간지연이 걸렸습니다.
 - 어떻게 분리할까 고민하고, asyncAfter 등등 다양한 시도를 해봤는데 안됐었습니다.
 - 그냥 NotificationCenter 두개를 만들면 됐습니다.
 - 고민한 시간에 비해 너무 쉽게 해결되어 현타가 왔습니다.


**2. 하이라이트 사용중 다른모드로 이동해도 하이라이트가 그려지는 문제를 해결하였습니다.**
 - 하이라이트를 사용 후 다른 모드를 사용해도 하이라이트가 그려지는 문제가 갑자기 발생하였습니다.
 - 디자인이 수정되면서 기존 toolMode에서 .highlight였던 것들이 toolMode의 .drawing 안에 drawingToolMode의 .highlight가 되면서 발생하는 현상이었습니다.
 - 따라서 toolMode == .highlight에서 toolMode == .drawing && drawingToolMode == .highlight 일때만 적용되게 하여 문제를 해결했습니다.


**3. 이 문제는 그리기와 지우개 기능에서도 동일한 문제가 있습니다.**
 - 그리기와 지우개 기능을 사용 후 다른 모드로 이동해도 그리기와 지우개 기능이 실행됩니다.
 - 실행되는 부분이 어딘지 자세히 몰라 제가 고치지 못했습니다.
 - 저와 비슷하게 해결하면 될 것 같습니다.

