### PR TITLE
[Fix] 파일 업로드 버그 수정

### DIFF
--- a/Domain/UseCases/HomeViewUseCase.swift
+++ b/Domain/UseCases/HomeViewUseCase.swift
@@ -183,7 +183,7 @@ class DefaultHomeViewUseCase: HomeViewUseCase {
                 
                 
                 while dupNum < 100 {
-                    let tempURL = documentURL.appending(path: lastComponent.joined() + " (\(dupNum)).pdf")
+                    let tempURL = documentURL.appending(path: lastComponent.joined() + "(\(dupNum)).pdf")
                     
                     if !manager.fileExists(atPath: tempURL.path()) {
                         try manager.copyItem(at: url, to: tempURL)


### PR DESCRIPTION
## 변경 사항
- [ ] 파일 copy 할 때에 url 수정


## 스크린샷 or 영상 링크

파일을 카피할 때 url에 공백이 들어갔었는데 해당 공백이 실제 url에서는 인식이 되지는 않은것 같습니다. 
그래서 파일이 있는데 없다고 인식하여 계속 같은 파일 이름으로 카피를 요청해서 에러가 나는 것으로 확인했습니다.
일단은 공백을 지웠고 공백이 꼭 필요하다고 판단되면 다른 방법으로 넣도록 하겠습니다!


close #262 