### PR TITLE
[Fix] 파일 업로드 url permission 수정

### DIFF
--- a/Domain/UseCases/HomeViewUseCase.swift
+++ b/Domain/UseCases/HomeViewUseCase.swift
@@ -69,6 +69,12 @@ class DefaultHomeViewUseCase: HomeViewUseCase {
     public func uploadPDFFile(url: [URL], folderID: UUID?) throws -> PaperInfo? {
         guard let url = url.first else { return nil }
         
+        guard url.startAccessingSecurityScopedResource() else {
+            return nil
+        }
+        
+        defer { url.stopAccessingSecurityScopedResource() }
+        
         let tempDoc = PDFDocument(url: url)
 
         
@@ -173,6 +179,10 @@ class DefaultHomeViewUseCase: HomeViewUseCase {
             let manager = FileManager.default
             let documentURL = manager.urls(for: .documentDirectory, in: .userDomainMask).first!
             let fileURL = documentURL.appending(path: url.lastPathComponent)
+            
+            // TODO: url 오류 대응
+            guard url.startAccessingSecurityScopedResource() else { return nil }
+            defer { url.stopAccessingSecurityScopedResource() }
             
             if manager.fileExists(atPath: fileURL.path()) {
                 var dupNum = 1


### PR DESCRIPTION
## 변경 사항
- [ ] 파일 url 사용시 permission을 주지 않아 사용이 되지 않는 현상 수정


## 스크린샷 or 영상 링크
사용자 디렉토리의 url을 사용할 경우 permission을 받고 사용해야 하는데 빼버렸네요.
저번에 실기기에 테스트 할 때 해당 코드를 지워도 작동이 잘 되길레 빼버렸는데 갑자기 또 안되버리네요;;
오류 처리는 나중에 진행하겠습니다.

close #267 