### PR TITLE
[Feat] setting view 수정 사항

### DIFF
--- a/Presentation/Home/HomeView.swift
+++ b/Presentation/Home/HomeView.swift
@@ -193,11 +193,7 @@ struct HomeView: View {
             
             // 세팅 메뉴 뷰
             if homeViewModel.isSettingMenu {
-                if #available(iOS 18.0, *) {
-                    SettingView()
-                } else {
-                    
-                }
+                SettingView()
             }
         }
         .background(Color(hex: "F7F7FB"))

--- a/Presentation/Home/SettingView.swift
+++ b/Presentation/Home/SettingView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 import StoreKit
 import Translation
 
-@available(iOS 18.0, *)
 struct SettingView: View {
     private var email = SupportEmail()
     


### PR DESCRIPTION
## 변경 사항
- [ ] 번역 기능 지웠습니다!
- [ ] 뷰 아래에 저작권 추가

언어 버튼을 눌러도 다운로드 창이 뜨지 않았던 이유가 ,, 
해당 언어를 이미 다운로드한 경우엔 창이 아예 안뜨더라구요??! 
근데 또 기존에 펑키가 구현해준 번역 버튼을 누를 시, 
해당 언어가 다운로드 되어 있지 않을 경우에도 다운로드 창이 뜹니다 
그래서 설정 창에 있는 기능은 지우기로 했어요

## 스크린샷 or 영상 링크
![Simulator Screenshot - iPad Air 13-inch (M2) - 2024-11-25 at 21 26 39](https://github.com/user-attachments/assets/8c16cd22-0331-431c-ade8-f7df2e831566)


## 팀원에게 전달할 사항(Optional)
이제 코멘트뷰 위치 조정하는 거 해보겠습니다

