### PR TITLE
[Fix] 논문에 따른 하이라이트 굵기 조절

### DIFF
--- a/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
+++ b/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
@@ -176,24 +176,41 @@ extension MainPDFViewModel {
 extension MainPDFViewModel {
     // 하이라이트 기능
     func highlightText(in pdfView: PDFView, with color: HighlightColors) {
+        
         guard pdfDrawer.drawingTool == .highlights else { return }
-
-        // PDFView 안에서 스크롤 영역 파악
-        guard let currentSelection = pdfView.currentSelection else { return }
-
-        // 선택된 텍스트를 줄 단위로 나눔
-        let selections = currentSelection.selectionsByLine()
-
+        
+        guard let currentSelection = pdfView.currentSelection else { return }               // PDFView 안에서 스크롤 영역 파악
+        let selections = currentSelection.selectionsByLine()                                // 선택된 텍스트를 줄 단위로 나눔
         guard let page = selections.first?.pages.first else { return }
 
         let highlightColor = color.uiColor
 
         selections.forEach { selection in
-            var bounds = selection.bounds(for: page)
             
+            var bounds = selection.bounds(for: page)
             let originBoundsHeight = bounds.size.height
-            bounds.size.height *= 0.6                                                   // bounds 높이 조정하기
-            bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2            // 줄인 높인만큼 y축 이동
+            
+            print("Original bounds height: \(originBoundsHeight)")
+            
+            if originBoundsHeight > 18 {
+                bounds.size.height *= 0.45
+                bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2
+            } else if originBoundsHeight > 16 {
+                bounds.size.height *= 0.5
+                bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2
+            } else if originBoundsHeight > 11 {
+                bounds.size.height *= 0.55
+                bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2
+            } else if originBoundsHeight > 10 {
+                bounds.size.height *= 0.6
+                bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2
+            } else if originBoundsHeight > 9 {
+                bounds.size.height *= 0.7
+                bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2
+            } else {
+                bounds.size.height *= 0.8                                                   // bounds 높이 조정하기
+                bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2            // 줄인 높인만큼 y축 이동
+            }
 
             let highlight = PDFAnnotation(bounds: bounds, forType: .highlight, withProperties: nil)
             highlight.endLineStyle = .none
@@ -234,8 +251,26 @@ extension MainPDFViewModel {
                         
                         /// 하이라이트 높이 조정
                         let originalBoundsHeight = bounds.size.height
-                        bounds.size.height *= 0.6
-                        bounds.origin.y += (originalBoundsHeight - bounds.height) / 2
+                        
+                        if originalBoundsHeight > 18 {
+                            bounds.size.height *= 0.45
+                            bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2
+                        } else if originalBoundsHeight > 16 {
+                            bounds.size.height *= 0.5
+                            bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2
+                        } else if originalBoundsHeight > 11 {
+                            bounds.size.height *= 0.55
+                            bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2
+                        } else if originalBoundsHeight > 10 {
+                            bounds.size.height *= 0.6
+                            bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2
+                        } else if originalBoundsHeight > 9 {
+                            bounds.size.height *= 0.7
+                            bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2
+                        } else {
+                            bounds.size.height *= 0.8                                                   // bounds 높이 조정하기
+                            bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2            // 줄인 높인만큼 y축 이동
+                        }
                         
                         let highlight = PDFAnnotation(bounds: bounds, forType: .highlight, withProperties: nil)
                         highlight.color = UIColor.comment


### PR DESCRIPTION
## 변경 사항
- [ ] 인식하는 bounds의 높이에 따라 하이라이트의 굵기를 조절하였습니다.


## 스크린샷 or 영상 링크
|

https://github.com/user-attachments/assets/270aed6d-9aee-4f29-a1a7-fba2bbf37cd0



## 팀원에게 전달할 사항(Optional)
| 
실제로 논문마다 bounds의 높이가 달랐고, 같은 논문이라도 줄마다 또 높이가 달랐습니다.
또한 같은 15의 bounds 높이를 가지고 있어도 조금 다르게 하이라이트가 칠해지는 경우도 있었습니다.
여러가지 시도해봤지만 조금씩 겹쳐서 나오는 경우도 있기는 합니다.
그래도 최대한 많은 논문을 포괄하도록 경우의 수를 나눠서 테스트한 다음 조절해보았습니다.

코멘트에 칠해지는 하이라이트도 똑같이 적용했습니다.

하이라이트 터치 인식과 중복 제거는 시간이 더 걸릴 것 같습니다.


