### PR TITLE
[Fix] 하이라이트 및 코멘트 굵기와 밑줄 위치 수정

### DIFF
--- a/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
+++ b/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
@@ -190,24 +190,23 @@ extension MainPDFViewModel {
             var bounds = selection.bounds(for: page)
             let originBoundsHeight = bounds.size.height
             
-            print("Original bounds height: \(originBoundsHeight)")
-            
-            if originBoundsHeight > 18 {
+            switch originBoundsHeight {
+            case 18... :
                 bounds.size.height *= 0.45
                 bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2
-            } else if originBoundsHeight > 16 {
+            case 16..<18 :
                 bounds.size.height *= 0.5
                 bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2
-            } else if originBoundsHeight > 11 {
+            case 11..<16 :
                 bounds.size.height *= 0.55
                 bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2
-            } else if originBoundsHeight > 10 {
+            case 10..<11 :
                 bounds.size.height *= 0.6
                 bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2
-            } else if originBoundsHeight > 9 {
+            case 9..<10 :
                 bounds.size.height *= 0.7
                 bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2
-            } else {
+            default :
                 bounds.size.height *= 0.8                                                   // bounds 높이 조정하기
                 bounds.origin.y += (originBoundsHeight - bounds.size.height) / 2            // 줄인 높인만큼 y축 이동
             }
@@ -252,22 +251,23 @@ extension MainPDFViewModel {
                         /// 하이라이트 높이 조정
                         let originalBoundsHeight = bounds.size.height
                         
-                        if originalBoundsHeight > 18 {
+                        switch originalBoundsHeight {
+                        case 18... :
                             bounds.size.height *= 0.45
                             bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2
-                        } else if originalBoundsHeight > 16 {
+                        case 16..<18 :
                             bounds.size.height *= 0.5
                             bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2
-                        } else if originalBoundsHeight > 11 {
+                        case 11..<16 :
                             bounds.size.height *= 0.55
                             bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2
-                        } else if originalBoundsHeight > 10 {
+                        case 10..<11 :
                             bounds.size.height *= 0.6
                             bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2
-                        } else if originalBoundsHeight > 9 {
+                        case 9..<10 :
                             bounds.size.height *= 0.7
                             bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2
-                        } else {
+                        default :
                             bounds.size.height *= 0.8                                                   // bounds 높이 조정하기
                             bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2            // 줄인 높인만큼 y축 이동
                         }

--- a/Presentation/OriginalPaper/Menus/Comment/ViewModel/CommentViewModel.swift
+++ b/Presentation/OriginalPaper/Menus/Comment/ViewModel/CommentViewModel.swift
@@ -450,8 +450,27 @@ extension CommentViewModel {
                 
                 /// 밑줄 높이 조정
                 let originalBoundsHeight = bounds.size.height
-                bounds.size.height *= 0.6
-                bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 2.5
+                
+                switch originalBoundsHeight {
+                case 18... :
+                    bounds.size.height *= 0.45
+                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3
+                case 16..<18 :
+                    bounds.size.height *= 0.5
+                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3
+                case 11..<16 :
+                    bounds.size.height *= 0.55
+                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3
+                case 10..<11 :
+                    bounds.size.height *= 0.6
+                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3
+                case 9..<10 :
+                    bounds.size.height *= 0.7
+                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3
+                default :
+                    bounds.size.height *= 0.8                                                   // bounds 높이 조정하기
+                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3          // 줄인 높인만큼 y축 이동
+                }
                 
                 let underline = PDFAnnotation(bounds: bounds, forType: .underline, withProperties: nil)
                 underline.color = .gray600


### PR DESCRIPTION
## 변경 사항
- [ ] 논문마다 다른 bounds의 높이에 따라 하이라이트의 굵기를 다르게 했습니다.
- [ ] 논문에 따라 코멘트의 하이라이트와 밑줄의 굵기와 위치를 조절하였습니다.
- [ ] 기존 If-else 문에서 switch 문으로 수정하여 가독성을 높였습니다.


## 스크린샷 or 영상 링크
|

https://github.com/user-attachments/assets/3948afa1-9bf2-45b1-8c91-01c44a943932



## 팀원에게 전달할 사항(Optional)
|
현재 하이라이트가 중복되지 않게 칠해지도록 기능을 구현하고 있습니다.
드래그 한 영역과 겹치는 부분을 확인하였고, 겹치지 않는 부분을 계산하는 데까지 구현되었습니다.
이제 겹치지 않는 부분만 하이라이트 치고, 겹치지 않는 부분은 쳐지지 않게만 하면 될 것 같습니다.
이상임다.
