### PR TITLE
[Fix] 코멘트뷰 위치 수정 및 리뷰 남기기 앱스토어 링크 연결

### DIFF
--- a/Presentation/Home/SettingView.swift
+++ b/Presentation/Home/SettingView.swift
@@ -10,6 +10,7 @@ import StoreKit
 import Translation
 
 struct SettingView: View {
+    let url = "https://apps.apple.com/app/id6737178157?action=write-review"
     private var email = SupportEmail()
     private var appVersion: String {
             let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
@@ -65,7 +66,10 @@ struct SettingView: View {
                     .foregroundStyle(.gray800)
                     
                     Button(action: {
-                        requestReview()
+                        guard let writeReviewURL = URL(string: url) else {
+                            fatalError("Expected a valid URL")
+                        }
+                        openURL(writeReviewURL)
                     }, label: {
                         HStack {
                             Text("앱스토어 리뷰 남기기")

--- a/Presentation/OriginalPaper/Menus/Comment/ViewModel/CommentViewModel.swift
+++ b/Presentation/OriginalPaper/Menus/Comment/ViewModel/CommentViewModel.swift
@@ -232,7 +232,7 @@ extension CommentViewModel {
             if bounds.size.height < comment.bounds.size.height {
                 bounds = comment.bounds
             } else if bounds.size.height == comment.bounds.size.height {
-                if bounds.origin.x < comment.bounds.origin.x {
+                if bounds.origin.x > comment.bounds.origin.x {
                     bounds.size.width = bounds.maxX - comment.bounds.minX
                     bounds.origin.x = comment.bounds.origin.x
                 } else {


### PR DESCRIPTION
## 변경 사항
- [ ] 코멘트 뷰가 드래그한 텍스트 영역 중앙에 정렬되고 있지 않는 것 같아 수정 함
- [ ] 앱 리뷰남기기를 누를 때 우리 앱 앱스터어의 리뷰 모달창까지 뜨도록 연결


## 스크린샷 or 영상 링크

https://github.com/user-attachments/assets/5c35c114-861b-43d7-9f2f-7823625dfa52


## 팀원에게 전달할 사항(Optional)

업데이트 고

close #365 
