### PR TITLE
[Fix] iOS 17.4에서 FigureView 열리지 않는 오류 해결

### DIFF
--- a/Domain/Entities/FigureAnnotation.swift
+++ b/Domain/Entities/FigureAnnotation.swift
@@ -19,5 +19,29 @@ struct FigureAnnotation: Hashable {
     public func toDTO() -> Figure {
         .init(id: id, head: head, coords: coords)
     }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid)
+        hasher.combine(id)
+        hasher.combine(page)
+        hasher.combine(head)
+        hasher.combine(coords)
+        
+        // CGRect를 속성별로 나눠 해싱
+        hasher.combine(position.origin.x)
+        hasher.combine(position.origin.y)
+        hasher.combine(position.size.width)
+        hasher.combine(position.size.height)
+    }
+    
+    static func == (lhs: FigureAnnotation, rhs: FigureAnnotation) -> Bool {
+        return lhs.uuid == rhs.uuid &&
+        lhs.id == rhs.id &&
+        lhs.page == rhs.page &&
+        lhs.head == rhs.head &&
+        lhs.coords == rhs.coords &&
+        lhs.position.origin == rhs.position.origin &&
+        lhs.position.size == rhs.position.size
+    }
 }
 


### PR DESCRIPTION
## 변경 사항
- [ ] iOS 17.4에서 FigureView가 열리지 않는 오류 해결
기억하세요... Hashable의 hash 함수는 17.4와 18.0에서 다르게 작용합니다

## 팀원에게 전달할 사항(Optional)
ㅈㄱㄴ

close #388 