### PR TITLE
[Fix] 페이지 리스트 뷰 오류 수정

### DIFF
--- a/Presentation/OriginalPaper/Menus/PageList/Views/ThumbnailTableViewCell.swift
+++ b/Presentation/OriginalPaper/Menus/PageList/Views/ThumbnailTableViewCell.swift
@@ -39,6 +39,12 @@ class ThumbnailTableViewCell: UITableViewCell {
         return label
     }()
     
+    // thumbnailView 제약조건
+    private var thumbnailConstraints: [NSLayoutConstraint] = []
+    
+    // pageNumLabelView 제약조건
+    private var pageNumConstraints: [NSLayoutConstraint] = []
+    
     init(pageNum: Int, thumbnail: UIImage) {
         self.pageNum = pageNum
         self.thumbnail = thumbnail
@@ -74,22 +80,36 @@ extension ThumbnailTableViewCell {
         self.addSubview(pageNumLabel)
         self.addSubview(thumbnailView)
         
-        let viewWidth = UIScreen.main.bounds.width * 0.22 * 0.7
+        let viewWidth = UIScreen.main.bounds.width * 0.22 * 0.65
         
         let ratio = thumbnail.size.width / thumbnail.size.height
         
-        NSLayoutConstraint.activate([
-            thumbnailView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            thumbnailView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            thumbnailView.heightAnchor.constraint(equalToConstant: viewWidth ),
-            thumbnailView.widthAnchor.constraint(equalToConstant: viewWidth * ratio)
-        ])
+        if ratio > 1 {
+            let heightRatio = thumbnail.size.height / thumbnail.size.width
+            
+            self.thumbnailConstraints.append(contentsOf: [
+                thumbnailView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+                thumbnailView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+                thumbnailView.heightAnchor.constraint(equalToConstant: viewWidth * heightRatio ),
+                thumbnailView.widthAnchor.constraint(equalToConstant: viewWidth )
+            ])
+        } else {
+            self.thumbnailConstraints.append(contentsOf: [
+                thumbnailView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+                thumbnailView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+                thumbnailView.heightAnchor.constraint(equalToConstant: viewWidth ),
+                thumbnailView.widthAnchor.constraint(equalToConstant: viewWidth * ratio )
+            ])
+        }
         
-        NSLayoutConstraint.activate([
+        self.pageNumConstraints.append(contentsOf: [
             pageNumLabel.trailingAnchor.constraint(equalTo: thumbnailView.leadingAnchor),
             pageNumLabel.topAnchor.constraint(equalTo: thumbnailView.topAnchor),
             pageNumLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
         ])
+        
+        NSLayoutConstraint.activate(thumbnailConstraints)
+        NSLayoutConstraint.activate(pageNumConstraints)
     }
     
     /// Notification에 따른 Cell UI 수정
@@ -116,5 +136,24 @@ extension ThumbnailTableViewCell {
         thumbnailView.layer.borderColor = UIColor.primary3.cgColor
         pageNumLabel.textColor = .init(hex: "9092A9")
         pageNumLabel.font = .reazyManualFont(.medium, size: 14)
+    }
+    
+    // 화면이 회전되었을 때 레이아웃 수정
+    public func updateOrientationConstraints() {
+        let heightAnchor = self.thumbnailConstraints.first { $0.firstAttribute == .height }
+        let widthAnchor = self.thumbnailConstraints.first { $0.firstAttribute == .width }
+        
+        let viewWidth = UIScreen.main.bounds.width * 0.22 * 0.65
+
+        let ratio = thumbnail.size.width / thumbnail.size.height
+
+        if ratio > 1 {
+            let newRatio = thumbnail.size.height / thumbnail.size.width
+            heightAnchor?.constant = viewWidth * newRatio
+            widthAnchor?.constant = viewWidth
+        } else {
+            heightAnchor?.constant = viewWidth
+            widthAnchor?.constant = viewWidth * ratio
+        }
     }
 }

--- a/Presentation/OriginalPaper/Menus/PageList/Views/ThumbnailTableViewController.swift
+++ b/Presentation/OriginalPaper/Menus/PageList/Views/ThumbnailTableViewController.swift
@@ -68,11 +68,9 @@ extension ThumbnailTableViewController {
             self.thumbnailTableView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
             self.thumbnailTableView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
         ])
-        
     }
     
     private func setBinding() {
-        
         self.pageListViewModel.$changedPageNumber
             .sink { [weak self] num in
                 guard let self = self, let num = num else { return }
@@ -99,12 +97,12 @@ extension ThumbnailTableViewController {
         
         NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)
             .sink { [weak self] _ in
+                self?.preRenderedCells.forEach { $0.updateOrientationConstraints() }
                 self?.redrawScreen()
             }
             .store(in: &self.cancellables)
     }
     
-
     private func redrawScreen() {
         self.thumbnailTableView.reloadData()
     }


### PR DESCRIPTION
## 변경 사항
- [ ] ThumbnailTableViewCell의 image 비율에 따른 분기 처리 설정
- [ ] ratio가 1이 넘을 때(가로가 더 길 때) 가로 길이가 고정되게 수정
- [ ] 화면 회전 시 그에 맞게 Cell의 layout이 재조정 되게 수정


## 스크린샷 or 영상 링크

https://github.com/user-attachments/assets/1a3f0e61-d43d-4a7f-b692-55394605eed2



close #402 

