### PR TITLE
[Feat] Cloud에서 PDF 업로드 구현

### DIFF
--- a/Domain/UseCases/HomeViewUseCase.swift
+++ b/Domain/UseCases/HomeViewUseCase.swift
@@ -73,13 +73,12 @@ class DefaultHomeViewUseCase: HomeViewUseCase {
         
         let _ = url.startAccessingSecurityScopedResource()
         defer { url.stopAccessingSecurityScopedResource() }
-        
-        let tempDoc = PDFDocument(url: url)
 
-        
         guard let urlData = try? self.savePDFIntoDirectory(url: url, isSample: false) else {
             throw PDFUploadError.fileNameDuplication
         }
+        
+        let tempDoc = PDFDocument(url: urlData.1)
         
         let title = urlData.1.deletingPathExtension().lastPathComponent
         
@@ -342,9 +341,16 @@ class DefaultHomeViewUseCase: HomeViewUseCase {
             let manager = FileManager.default
             let documentURL = manager.urls(for: .documentDirectory, in: .userDomainMask).first!
             let fileURL = documentURL.appending(path: url.lastPathComponent)
-            
+                        
             let _ = url.startAccessingSecurityScopedResource()
             defer { url.stopAccessingSecurityScopedResource() }
+            
+            var error: NSError?
+            
+            // 업로드 전 로컬에 다운로드 진행
+            NSFileCoordinator().coordinate(readingItemAt: url, options: .forUploading, error: &error) { _ in
+//                print("coordinated URL: \(cloudURL)")
+            }
             
             if let _ = try? Data(contentsOf: fileURL) {
                 var dupNum = 1

--- a/Presentation/Home/HomeView.swift
+++ b/Presentation/Home/HomeView.swift
@@ -198,6 +198,12 @@ struct HomeView: View {
             if homeViewModel.isSettingMenu {
                 SettingView()
             }
+            
+            if homeViewModel.isLoading {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .tint(.primary1)
+            }
         }
         .background(Color(hex: "F7F7FB"))
         .ignoresSafeArea(edges: .top)
@@ -299,6 +305,7 @@ private struct MainMenuView: View {
             
             Button(action: {
                 self.isFileImporterPresented.toggle()
+                self.homeViewModel.isLoading = true
             }) {
                 Text("가져오기")
                     .reazyFont(.button1)
@@ -311,6 +318,11 @@ private struct MainMenuView: View {
             allowedContentTypes: [.pdf],
             allowsMultipleSelection: false,
             onCompletion: importPDFToDevice)
+        .onChange(of: isFileImporterPresented) { _, newValue in
+            if !newValue {
+                self.homeViewModel.isLoading = false
+            }
+        }
     }
     
     private enum ErrorStatus {

--- a/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -114,6 +114,8 @@ class HomeViewModel: ObservableObject {
 
 extension HomeViewModel {
     public func uploadPDF(url: [URL]) -> UUID? {
+        defer { self.isLoading = false }
+        
         do {
             let currentFolderID = currentFolder?.id
             


### PR DESCRIPTION
## 변경 사항
- [ ] PDF 업로드 메소드 수정(업로드 전 로컬에 다운로드 먼저 진행하게)
- [ ] 업로드 중 로딩 바 구현(다운로드 시 일정 시간 소요)


## 스크린샷 or 영상 링크

https://github.com/user-attachments/assets/da5a18d3-6728-4db5-9fb5-4a1cd478dc21



## 팀원에게 전달할 사항(Optional)

클라우드에서 업로드가 되지 않던 현상은 cloud에 파일이 있어 로컬에 저장이 되어 있지 않기 때문에 업로드 할 파일을 찾을 수 없어 발생하는 오류였습니다.

해결 방법으로 해당 메소드를 사용해 다운로드를 진행했습니다.
이 메소드는 찾아 본 결과 파일을 확인 할 때 사용이 되는데 해당 과정을 진행하려면 다운로드가 되어야 하기 때문에 이 메소드를 사용하면 자동으로 로컬에 다운로드가 됩니다.
그래서 해당 메소드 사용 후 pdf를 앱 내 샌드박스로 업로드 하게 됩니다.
```swift
NSFileCoordinator().coordinate(readingItemAt: url, options: .forUploading, error: &error) { _ in
    ...
}
```
참고로 업로드 전 파일 정보 같은 메타데이터를 확인한 후에 업로드를 하면 정상적으로 되는데 위 메소드와 같은 원리라고 볼 수 있습니다!


close #406 

