### PR TITLE
[Chore] 애플 펜슬 더블 탭 제스처로 펜슬 <-> 지우개 스위치

### DIFF
--- a/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
+++ b/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
@@ -51,6 +51,28 @@ final class MainPDFViewModel: ObservableObject {
     
     // pencil tool
     public var pdfDrawer: PDFDrawer = .init()
+    @Published var isHighlight: Bool = false
+    @Published var isPencil: Bool = false
+    @Published var isEraser: Bool = false
+    
+    @Published var selectedPenColor: PenColors?
+    @Published var tempPenColor: PenColors?
+    
+    
+    func toggleHighlight() {
+        isHighlight.toggle()
+        pdfDrawer.drawingTool = isHighlight ? .highlights : .none
+    }
+
+    func togglePencil() {
+        isPencil.toggle()
+        pdfDrawer.drawingTool = isPencil ? .pencil : .none
+    }
+    
+    func toggleEraser() {
+        isEraser.toggle()
+        pdfDrawer.drawingTool = isEraser ? .eraser : .none
+    }
     
     // 현재 undo와 redo 가능 여부
     @Published var canUndo: Bool = false

--- a/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
+++ b/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
@@ -37,10 +37,7 @@ final class MainPDFViewModel: ObservableObject {
     
     // BubbleView의 상태와 위치
     @Published var translateViewPosition: CGRect = .zero
-    
-    // 하이라이트 색상
-    @Published var selectedHighlightColor: HighlightColors = .yellow
-    
+
     // Comment
     @Published var isCommentTapped: Bool = false
     @Published var selectedComments: [Comment] = []
@@ -49,14 +46,17 @@ final class MainPDFViewModel: ObservableObject {
     @Published var commentInputPosition: CGPoint = .zero
     @Published var isCommentSaved: Bool = false
     
-    // pencil tool
+    // Drawing tool
     public var pdfDrawer: PDFDrawer = .init()
     @Published var isHighlight: Bool = false
     @Published var isPencil: Bool = false
     @Published var isEraser: Bool = false
     
+    @Published var previousTool: DrawingTool?
     @Published var selectedPenColor: PenColors?
+    @Published var selectedHighlightColor: HighlightColors?
     @Published var tempPenColor: PenColors?
+    @Published var tempHighlightColor: HighlightColors?
     
     
     func toggleHighlight() {

--- a/Presentation/OriginalPaper/Menus/Drawing/DrawingView.swift
+++ b/Presentation/OriginalPaper/Menus/Drawing/DrawingView.swift
@@ -9,20 +9,16 @@ import SwiftUI
 
 struct DrawingView: View {
     @EnvironmentObject private var mainPDFViewModel: MainPDFViewModel
-    @State private var selectedHighlightColor: HighlightColors?
-    @State private var selectedPenColor: PenColors?
-
-    @State var isHighlight: Bool = false
-    @State var isPencil: Bool = false
-    @State var isEraser: Bool = false
-    @Binding var selectedButton: Buttons? 
+    @State var selectedHighlightColor: HighlightColors?
+    @State var selectedPenColor: PenColors?
+    @Binding var selectedButton: Buttons?
 
     var body: some View {
         VStack(spacing: 0) {
             Button(action: {
-                isHighlight.toggle()
+                mainPDFViewModel.toggleHighlight()
                 
-                if isHighlight {
+                if mainPDFViewModel.isHighlight {
                     mainPDFViewModel.pdfDrawer.drawingTool = .highlights
                     mainPDFViewModel.toolMode = .drawing
                 } else {
@@ -35,12 +31,12 @@ struct DrawingView: View {
                     selectedHighlightColor = nil
                 }
 
-                isPencil = false
-                selectedPenColor = nil
-                isEraser = false
+                mainPDFViewModel.isPencil = false
+                mainPDFViewModel.selectedPenColor = nil
+                mainPDFViewModel.isEraser = false
             }) {
                 RoundedRectangle(cornerRadius: 6)
-                    .foregroundStyle(isHighlight ? .primary3 : .clear)
+                    .foregroundStyle(mainPDFViewModel.isHighlight ? .primary3 : .clear)
                     .frame(width: 26, height: 26)
                     .overlay(
                         Image(.highlight)
@@ -55,14 +51,14 @@ struct DrawingView: View {
 
             ForEach(HighlightColors.allCases, id: \.self) { color in
                 HighlightColorButton(button: $selectedHighlightColor, selectedButton: color) {
-                    isHighlight = true
+                    mainPDFViewModel.isHighlight = true
                     selectedHighlightColor = color
                     mainPDFViewModel.pdfDrawer.drawingTool = .highlights
                     mainPDFViewModel.selectedHighlightColor = color
 
-                    isPencil = false
-                    selectedPenColor = nil
-                    isEraser = false
+                    mainPDFViewModel.isPencil = false
+                    mainPDFViewModel.selectedPenColor = nil
+                    mainPDFViewModel.isEraser = false
                 }
                 .padding(.bottom, color == .blue ? 16 : 10)
             }
@@ -73,9 +69,9 @@ struct DrawingView: View {
                 .padding(.bottom, 12)
 
             Button(action: {
-                isPencil.toggle()
+                mainPDFViewModel.togglePencil()
                 
-                if isPencil {
+                if mainPDFViewModel.isPencil {
                     mainPDFViewModel.toolMode = .drawing
                     mainPDFViewModel.pdfDrawer.drawingTool = .pencil
                 } else {
@@ -85,16 +81,18 @@ struct DrawingView: View {
                 
                 if selectedPenColor == nil {
                     selectedPenColor = .black
+                    mainPDFViewModel.selectedPenColor = .black
                 } else {
                     selectedPenColor = nil
+                    mainPDFViewModel.selectedPenColor = nil
                 }
 
-                isHighlight = false
+                mainPDFViewModel.isHighlight = false
                 selectedHighlightColor = nil
-                isEraser = false
+                mainPDFViewModel.isEraser = false
             }) {
                 RoundedRectangle(cornerRadius: 6)
-                    .foregroundStyle(isPencil ? .primary3 : .clear)
+                    .foregroundStyle(mainPDFViewModel.isPencil ? .primary3 : .clear)
                     .frame(width: 26, height: 26)
                     .overlay(
                         Image(.pencil)
@@ -109,14 +107,14 @@ struct DrawingView: View {
 
             ForEach(PenColors.allCases, id: \.self) { color in
                 PenColorButton(button: $selectedPenColor, selectedButton: color) {
-                    isPencil = true
-                    selectedPenColor = color
+                    mainPDFViewModel.isPencil = true
+                    mainPDFViewModel.selectedPenColor = color
                     mainPDFViewModel.pdfDrawer.drawingTool = .pencil
-                    mainPDFViewModel.pdfDrawer.penColor = selectedPenColor!
+                    mainPDFViewModel.pdfDrawer.penColor = mainPDFViewModel.selectedPenColor!
 
-                    isHighlight = false
+                    mainPDFViewModel.isHighlight = false
                     selectedHighlightColor = nil
-                    isEraser = false
+                    mainPDFViewModel.isEraser = false
                 }
                 .padding(.bottom, color == .green ? 16 : 10)
             }
@@ -127,22 +125,22 @@ struct DrawingView: View {
                 .padding(.bottom, 12)
 
             Button(action: {
-                isEraser.toggle()
+                mainPDFViewModel.toggleEraser()
                 
-                if isEraser {
+                if mainPDFViewModel.isEraser {
                     mainPDFViewModel.pdfDrawer.drawingTool = .eraser
                 } else {
                     mainPDFViewModel.pdfDrawer.drawingTool = .none
                 }
 
-                isPencil = false
-                selectedPenColor = nil
+                mainPDFViewModel.isPencil = false
+                mainPDFViewModel.selectedPenColor = nil
 
-                isHighlight = false
+                mainPDFViewModel.isHighlight = false
                 selectedHighlightColor = nil
             }) {
                 RoundedRectangle(cornerRadius: 6)
-                    .foregroundStyle(isEraser ? .primary3 : .clear)
+                    .foregroundStyle(mainPDFViewModel.isEraser ? .primary3 : .clear)
                     .frame(width: 26, height: 26)
                     .overlay(
                         Image(systemName: "eraser")
@@ -206,5 +204,11 @@ struct DrawingView: View {
         }
         .padding(.vertical, 16)
         .padding(.horizontal, 10)
+        .onAppear {
+            selectedPenColor = mainPDFViewModel.selectedPenColor
+        }
+        .onChange(of: mainPDFViewModel.selectedPenColor){
+            selectedPenColor = mainPDFViewModel.selectedPenColor
+        }
     }
 }

--- a/Presentation/OriginalPaper/Menus/Drawing/DrawingView.swift
+++ b/Presentation/OriginalPaper/Menus/Drawing/DrawingView.swift
@@ -52,9 +52,9 @@ struct DrawingView: View {
             ForEach(HighlightColors.allCases, id: \.self) { color in
                 HighlightColorButton(button: $selectedHighlightColor, selectedButton: color) {
                     mainPDFViewModel.isHighlight = true
-                    selectedHighlightColor = color
                     mainPDFViewModel.pdfDrawer.drawingTool = .highlights
                     mainPDFViewModel.selectedHighlightColor = color
+                    selectedHighlightColor = color
 
                     mainPDFViewModel.isPencil = false
                     mainPDFViewModel.selectedPenColor = nil
@@ -206,9 +206,13 @@ struct DrawingView: View {
         .padding(.horizontal, 10)
         .onAppear {
             selectedPenColor = mainPDFViewModel.selectedPenColor
+            selectedHighlightColor = mainPDFViewModel.selectedHighlightColor
         }
         .onChange(of: mainPDFViewModel.selectedPenColor){
             selectedPenColor = mainPDFViewModel.selectedPenColor
+        }
+        .onChange(of: mainPDFViewModel.selectedHighlightColor){
+            selectedHighlightColor = mainPDFViewModel.selectedHighlightColor
         }
     }
 }

--- a/Presentation/OriginalPaper/OriginalViewController.swift
+++ b/Presentation/OriginalPaper/OriginalViewController.swift
@@ -500,9 +500,15 @@ extension OriginalViewController: UIPencilInteractionDelegate {
         print("Double tap detected")
         if self.viewModel.pdfDrawer.drawingTool == .pencil {
             self.viewModel.pdfDrawer.drawingTool = .eraser
+            self.viewModel.isPencil = false
+            self.viewModel.isEraser = true
+            self.viewModel.tempPenColor = self.viewModel.selectedPenColor ?? .black
+            self.viewModel.selectedPenColor = nil
         } else if self.viewModel.pdfDrawer.drawingTool == .eraser {
             self.viewModel.pdfDrawer.drawingTool = .pencil
+            self.viewModel.isPencil = true
+            self.viewModel.isEraser = false
+            self.viewModel.selectedPenColor = self.viewModel.tempPenColor ?? .black
         }
-        print("Pencil mode toggled to: \(self.viewModel.pdfDrawer.drawingTool)")
     }
 }

--- a/Presentation/OriginalPaper/OriginalViewController.swift
+++ b/Presentation/OriginalPaper/OriginalViewController.swift
@@ -202,6 +202,7 @@ extension OriginalViewController {
         viewModel.pdfDrawer.pdfView = self.mainPDFView
         viewModel.pdfDrawer.drawingTool = .none
         
+        // 애플 펜슬 제스처
         let pencilInteraction = UIPencilInteraction()
         pencilInteraction.isEnabled = true
         pencilInteraction.delegate = self
@@ -497,7 +498,6 @@ class CustomPDFView: PDFView {
 // MARK: - 애플 펜슬 더블 탭 처리
 extension OriginalViewController: UIPencilInteractionDelegate {
     func pencilInteractionDidTap(_ interaction: UIPencilInteraction) {
-        print("Double tap detected")
         if self.viewModel.pdfDrawer.drawingTool == .pencil {
             self.viewModel.pdfDrawer.drawingTool = .eraser
             self.viewModel.isPencil = false


### PR DESCRIPTION
## 변경 사항
- [ ] 애플 펜슬 더블 탭 제스처로 펜슬 <-> 지우개 스위치


## 스크린샷 or 영상 링크
| 놀랍게도 더블탭으로 스위칭 중

https://github.com/user-attachments/assets/dbef1fef-ea26-4aa3-b9d1-36accc63cc0a


## 팀원에게 전달할 사항(Optional)
| 

- 더블 탭 제스처를 어떤 부분에 넣을까 고민했었는데, 드로잉 제스처랑은 구분할 필요가 있을 것 같기도 하고 애플 펜슬 제스처는 복잡한 기능이 들어가는 게 아니라서 `OriginalViewController` 안의 `setGestures()`에서 처리했습니다
- 기존엔 버튼을 직접 눌러서 -> 기능으로 연결이었는데, 이젠 내부적으로 변수가 바뀌어서 버튼이 눌린 상태로 UI가 변해야해서 DrawingView에서 @State로 처리하던 변수들을 제스처랑 엮으면서 `MainPDFViewModel.swift` 로 대량 이동시켰습니다 

