### PR TITLE
[Feat] 업데이트 알럿창 구현

### DIFF
--- a/Presentation/AppView.swift
+++ b/Presentation/AppView.swift
@@ -100,8 +100,7 @@ extension AppView {
             else { return }
             
             if let appStoreVersion = results[0]["version"] as? String {
-                // TODO: 임시 테스트용, 조건 수정
-                if currentVersion == appStoreVersion {
+                if currentVersion != appStoreVersion {
                     print("🔔Current Version: \(currentVersion), App Store Version: \(appStoreVersion)")
                     self.isUpdateAlertPresented.toggle()
                 }

--- a/Presentation/AppView.swift
+++ b/Presentation/AppView.swift
@@ -22,9 +22,6 @@ struct AppView: App {
         )
     )
     
-    @State private var isReset: Bool = false
-    let resetPublisher = NotificationCenter.default.publisher(for: .resetFlag)
-    
     var body: some Scene {
         WindowGroup {
             NavigationStack(path: $navigationCoordinator.path) {
@@ -45,9 +42,6 @@ struct AppView: App {
                 self.homeViewModel.setSample()
             }
             .onOpenURL(perform: openUrlScheme)
-            .onReceive(resetPublisher) { _ in
-                self.isReset.toggle()
-            }
         }
     }
 }

--- a/Presentation/AppView.swift
+++ b/Presentation/AppView.swift
@@ -42,12 +42,12 @@ struct AppView: App {
             .environmentObject(homeViewModel)
             .task {
                 self.homeViewModel.setSample()
-                await checkAppVersion()
+                await self.checkAppVersion()
             }
             .onOpenURL(perform: openUrlScheme)
             .alert("Reazy의 최신 버전을 확인해보세요!", isPresented: $isUpdateAlertPresented) {
                 Button("취소", role: .cancel, action: {})
-                Button("업데이트", role: .none, action: {})
+                Button("업데이트", role: .none, action: openAppStore)
             }
         }
     }
@@ -68,7 +68,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
 
 extension AppView {
-    
+    /// 외부 앱에서 업로드 시 실행 메소드
     private func openUrlScheme(_ url: URL) {
         let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         let items = components!.queryItems!
@@ -86,6 +86,7 @@ extension AppView {
         }
     }
     
+    /// 설치된 버전과 앱스토어 버전을 비교하는 메소드
     private func checkAppVersion() async {
         guard let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"]
                 as? String else { return }
@@ -99,11 +100,20 @@ extension AppView {
             else { return }
             
             if let appStoreVersion = results[0]["version"] as? String {
+                // TODO: 임시 테스트용, 조건 수정
                 if currentVersion == appStoreVersion {
-                    print("Current Version: \(currentVersion), App Store Version: \(appStoreVersion)")
+                    print("🔔Current Version: \(currentVersion), App Store Version: \(appStoreVersion)")
                     self.isUpdateAlertPresented.toggle()
                 }
             }
+        }
+    }
+    
+    /// 앱스토어 여는 메소드
+    private func openAppStore() {
+        if let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/6737178157"),
+           UIApplication.shared.canOpenURL(appStoreURL) {
+            UIApplication.shared.open(appStoreURL, options: [:], completionHandler: nil)
         }
     }
 }

--- a/Presentation/Helper/NotificationCenter + Extension.swift
+++ b/Presentation/Helper/NotificationCenter + Extension.swift
@@ -18,5 +18,4 @@ extension Notification.Name {
     static let isFigureCaptured = Notification.Name("isFigureCaptured")
     static let isCollectionCaptured = Notification.Name("isCollectionCaptured")
     static let changeHomePaperInfo = Notification.Name("changeHomePaperInfo")
-    static let resetFlag = Notification.Name("resetFlag")
 }

--- a/Presentation/Home/HomeView.swift
+++ b/Presentation/Home/HomeView.swift
@@ -53,9 +53,6 @@ struct HomeView: View {
                             .scaledToFit()
                             .frame(width: 62, height: 50)
                             .padding(.trailing, 36)
-                            .onTapGesture(count: 5) {
-                                NotificationCenter.default.post(name: .resetFlag, object: nil)
-                            }
                         
                         if !homeViewModel.isSearching {
                             Button(action: {

--- a/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -584,6 +584,7 @@ extension HomeViewModel {
     }
     
     /// Deprecated
+    /*
     public func resetViewModel() {
         PersistantContainer.shared.resetContainer()
         
@@ -623,4 +624,5 @@ extension HomeViewModel {
         UserDefaults.standard.set(false, forKey: "sample")
         self.setSample()
     }
+     */
 }

--- a/Presentation/OriginalPaper/OriginalViewController.swift
+++ b/Presentation/OriginalPaper/OriginalViewController.swift
@@ -37,14 +37,6 @@ final class OriginalViewController: UIViewController {
         return view
     }()
     
-    let testPDFView: PDFView = {
-        let view = PDFView()
-        view.backgroundColor = .gray200
-        view.autoScales = false
-        view.pageShadowsEnabled = false
-        return view
-    }()
-    
     let labelBackgroundView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
## 변경 사항
- [ ] 기기에 설치된 앱의 버전과 앱스토어에 올라온 버전이 다를 시 업데이트 알럿 구현
- [ ] 업데이트 버튼을 누를 시 앱스토어로 연결되게 구현


## 스크린샷 or 영상 링크
<img width="914" alt="스크린샷 2025-01-07 오후 3 36 01" src="https://github.com/user-attachments/assets/192e7e46-321f-4d7d-958e-c996e90d3336" />



## 팀원에게 전달할 사항(Optional)
테스트시 아래 코드를 수정하시면 됩니다.

in AppView.swift, checkAppVersion() method
`if currentVersion != appStoreVersion` -> `if currentVersion == appStoreVersion`

앱스토어로 연결 또한 잘 되는지 확인해봐주시면 감사하겠습니다.

close #422 

