### PR TITLE
[Fix] 코멘트 linecap 수정

### DIFF
--- a/Presentation/OriginalPaper/Menus/Comment/ViewModel/CommentViewModel.swift
+++ b/Presentation/OriginalPaper/Menus/Comment/ViewModel/CommentViewModel.swift
@@ -463,6 +463,27 @@ extension CommentViewModel {
     }
     
     /// 밑줄 그리기
+    class lineAnnotation: PDFAnnotation {
+        override func draw(with box: PDFDisplayBox, in context: CGContext) {
+            context.saveGState()
+            
+            // 스타일 설정
+            context.setLineWidth(2.4)
+            context.setLineCap(.round)
+            context.setStrokeColor(UIColor.point4.withAlphaComponent(0.4).cgColor)
+            
+            // 라인 그리기
+            let start = CGPoint(x: bounds.minX, y: bounds.minY)
+            let end = CGPoint(x: bounds.maxX, y: bounds.minY)
+            
+            context.move(to: start)
+            context.addLine(to: end)
+            context.strokePath()
+            
+            context.restoreGState()
+        }
+    }
+    
     func drawUnderline(newComment: Comment) {
         for index in newComment.pages {
             guard let page = document?.page(at: index) else { continue }
@@ -494,18 +515,7 @@ extension CommentViewModel {
                     bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3          // 줄인 높인만큼 y축 이동
                 }
                 
-                let underline = PDFAnnotation(bounds: bounds, forType: .line, withProperties: nil)
-                
-                // 두께
-                let border = PDFBorder()
-                border.lineWidth = 2.4
-                underline.border = border
-                
-                // line 시작,끝
-                underline.startPoint = .zero
-                underline.endPoint = CGPoint(x: bounds.width, y: 0)
-                
-                underline.color = .point4.withAlphaComponent(0.4)
+                let underline = lineAnnotation(bounds: bounds, forType: .line, withProperties: nil)
                 
                 underline.setValue(newComment.id.uuidString, forAnnotationKey: .contents)
                 page.addAnnotation(underline)


### PR DESCRIPTION
## 변경 사항
- [ ] 코멘트의 lineCap을 round로 수정햐였습니다


## 스크린샷 or 영상 링크
| 기본 pdfAnnotation으로는 lineCap을 round로 만드는 게 불가능해서 커스텀 annotation을 만들어 추가하였습니다!

![simulator_screenshot_D9677AC4-2914-4804-8DB8-58B6C1F912E5](https://github.com/user-attachments/assets/699d77c0-7df0-4acf-aa46-d905a086e900)


## 팀원에게 전달할 사항(Optional)
![image](https://github.com/user-attachments/assets/41f0172e-a3c7-4963-998f-cca5520e0081)

close #425 

