### PR TITLE
[Fix] editFigure 터치 범위 수정

### DIFF
--- a/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureMenu.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureMenu.swift
@@ -99,11 +99,17 @@ struct FigureMenu: View {
                     })
                     
                 } label: {
-                    Image(.editfigure)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 24, height: 24)
-                        .foregroundStyle(.gray600)
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color.clear)
+                            .frame(width: 24, height: 24)
+                        
+                        Image(.editfigure)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 20, height: 20)
+                            .foregroundStyle(.gray600)
+                    }
                 }
                 .foregroundStyle(.primary2)
                 .padding(.leading, 10)


### PR DESCRIPTION
## 변경 사항
- [x] editFigure 메뉴 크기 조정
- [x] editFigure 터치 범위 수정


## 스크린샷 or 영상 링크
|

![simulator_screenshot_DAABC8B0-436C-4119-B8B0-EE82BE05329C](https://github.com/user-attachments/assets/1698c345-9af3-4e81-b417-a115047179fc)


## 팀원에게 전달할 사항(Optional)
|
ZStack으로 보이지 않는 도형을 쌓아 메뉴의 터치 범위를 늘렸습니다.
파란색으로 표시된 범위가 실제 터치 범위입니다.
push할때는 범위 표시는 지우고 올렸습니다.

close #427 
