### PR TITLE
[Fix] 툴팁 구글 스칼라 검색 변경

### DIFF
--- a/Presentation/OriginalPaper/OriginalViewController.swift
+++ b/Presentation/OriginalPaper/OriginalViewController.swift
@@ -77,10 +77,10 @@ final class OriginalViewController: UIViewController {
         super.buildMenu(with: builder)
         
         /// web 검색 액션
-        let searchWebAction = UIAction(title: "Search Web", image: nil, identifier: nil) { action in
+        let searchWebAction = UIAction(title: "Google Scholar 검색", image: nil, identifier: nil) { action in
             if let selectedTextRange = self.mainPDFView.currentSelection?.string {
                 let query = selectedTextRange.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-                if let url = URL(string: "https://www.google.com/search?q=\(query)") {
+                if let url = URL(string: "https://scholar.google.co.kr/scholar?hl=ko&as_sdt=0%2C5&q=\(query)") {
                     UIApplication.shared.open(url)
                 }
             }
@@ -101,7 +101,7 @@ final class OriginalViewController: UIViewController {
                 return elements.filter { item in
                     switch (item as? UICommand)?.title.description {
                         ///translate, lookup 메뉴 들어가게
-                    case "Search Web" :
+                    case "Google Scholar" :
                         return true
                     default:
                         return false


### PR DESCRIPTION
## 변경 사항
- [ ] 툴팁 기존 'Search Web' 에서 'Google Scholar 검색'으로 변경하였습니다.

## 스크린샷 or 영상 링크
|

https://github.com/user-attachments/assets/fc0402d8-6f67-471d-91b8-19c3ffc36944



## 팀원에게 전달할 사항(Optional)
| 툴팁에서 기본으로 '복사하기, 공유'가 생깁니다. 없애거나 순서를 바꾸는 방법이 있는 것 같습니다. 일단은 그대로 해뒀습니다

close #432 