### PR TITLE
[Chore] FloatingView 최소 크기 수정

### DIFF
--- a/Presentation/OriginalPaper/Floating/FloatingView.swift
+++ b/Presentation/OriginalPaper/Floating/FloatingView.swift
@@ -151,7 +151,7 @@ struct FloatingView: View {
                     DragGesture()
                         .onChanged { value in
                             // 최대 크기 제한 850 + 최소 크기 제한 300
-                            let newWidth = max(min(viewWidth + value.translation.width, 850), 200)
+                            let newWidth = max(min(viewWidth + value.translation.width, 850), 500)
                             self.viewWidth = newWidth
                         }
                 )

--- a/Presentation/OriginalPaper/Floating/FloatingViewModel.swift
+++ b/Presentation/OriginalPaper/Floating/FloatingViewModel.swift
@@ -51,7 +51,7 @@ class FloatingViewModel: ObservableObject {
                 isSelected: true,
                 viewOffset: CGSize(width: 0, height: 0),
                 lastOffset: CGSize(width: 0, height: 0),
-                viewWidth: 300,
+                viewWidth: 500,
                 isInSplitMode: false,
                 isFigure: isFigure
             )

--- a/Presentation/OriginalPaper/Floating/FloatingViewsContainer.swift
+++ b/Presentation/OriginalPaper/Floating/FloatingViewsContainer.swift
@@ -45,7 +45,7 @@ struct FloatingViewsContainer: View {
                             get: { droppedFigure.viewWidth },
                             set: { newValue in
                                 if let index = floatingViewModel.droppedFigures.firstIndex(where: { $0.id == droppedFigure.id }) {
-                                    floatingViewModel.droppedFigures[index].viewWidth = max(newValue, 200)
+                                    floatingViewModel.droppedFigures[index].viewWidth = max(newValue, 500)
                                 }
                             }
                         )

--- a/Presentation/OriginalPaper/Menus/FigureList/Collection/CollectionView.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Collection/CollectionView.swift
@@ -40,7 +40,7 @@ struct CollectionView: View {
                                         isSelected: true,
                                         viewOffset: CGSize(width: 0, height: 0),
                                         lastOffset: CGSize(width: 0, height: 0),
-                                        viewWidth: 300,
+                                        viewWidth: 500,
                                         isInSplitMode: true,
                                         isFigure: false
                                     )

--- a/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureView.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureView.swift
@@ -141,7 +141,7 @@ private struct FigureCompleteView: View {
                                 isSelected: true,
                                 viewOffset: CGSize(width: 0, height: 0),
                                 lastOffset: CGSize(width: 0, height: 0),
-                                viewWidth: 300,
+                                viewWidth: 500,
                                 isInSplitMode: true,
                                 isFigure: true
                             )


### PR DESCRIPTION
## 변경 사항
- [ ] FloatingView 최소 크기를 200(300)에서 500으로 수정하였습니다!
_근데 코드를 수정하고 보니 FloatingView 자체의 크기가 500보다 더 작게 조정이 되지 않는 것 같아 이에 대한 추가적인 확인은 필요해 보여요 👍_


## 스크린샷 or 영상 링크
- **최소가 아래 사진과 같은 사이즈로 뜹니다!**

![Simulator Screenshot - iPad Air 11-inch (M2) - 2025-01-19 at 14 41 41](https://github.com/user-attachments/assets/4f66fb87-5dee-4078-948e-10f040764279)



## 팀원에게 전달할 사항(Optional)
> 이후에 FloatingView 작게 조정할 수 있도록 수정 볼 예정입니다 최대한 빨리 확인해서 다시 PR 올릴게요!

close #423 
