### PR TITLE
[Chore] SplitView 디자인 반영 및 Split 오류 수정

### DIFF
--- a/Presentation/MainPDF/MainPDFView.swift
+++ b/Presentation/MainPDF/MainPDFView.swift
@@ -560,7 +560,7 @@ private struct MainOriginalView: View {
                                                         .foregroundStyle(.gray200)
                                                         .padding(.vertical, 5)
                                                 }
-                                                .gesture(
+                                                .highPriorityGesture(
                                                     DragGesture()
                                                         .onChanged { value in
                                                             let newHeight = dynamicHeight + value.translation.height
@@ -615,7 +615,7 @@ private struct MainOriginalView: View {
                                                         .foregroundStyle(.gray200)
                                                         .padding(.vertical, 5)
                                                 }
-                                                .gesture(
+                                                .highPriorityGesture(
                                                     DragGesture()
                                                         .onChanged { value in
                                                             let newHeight = dynamicHeight - value.translation.height
@@ -673,7 +673,7 @@ private struct MainOriginalView: View {
                                                     .foregroundStyle(.gray200)
                                                     .padding(.horizontal, 5)
                                             }
-                                            .gesture(
+                                            .highPriorityGesture(
                                                 DragGesture()
                                                     .onChanged { value in
                                                         let newWidth = dynamicWidth + value.translation.width
@@ -723,7 +723,7 @@ private struct MainOriginalView: View {
                                                     .foregroundStyle(.gray200)
                                                     .padding(.horizontal, 5)
                                             }
-                                            .gesture(
+                                            .highPriorityGesture(
                                                 DragGesture()
                                                     .onChanged { value in
                                                         let newWidth = dynamicWidth - value.translation.width

--- a/Presentation/MainPDF/MainPDFView.swift
+++ b/Presentation/MainPDF/MainPDFView.swift
@@ -544,18 +544,20 @@ private struct MainOriginalView: View {
                                                     mainPDFViewModel.isPaperViewFirst.toggle()
                                                 }
                                             },
-                                            isVertical: true
+                                            isVertical: true,
+                                            dynamicHeight: $dynamicHeight
                                         )
                                         
                                         VStack(spacing: 0) {
                                             Spacer()
                                             Rectangle()
-                                                .frame(width: 120, height: 20)
-                                                .foregroundStyle(.clear)
+                                                .frame(height: 8)
+                                                .foregroundStyle(.gray550)
                                                 .contentShape(Rectangle())
                                                 .overlay {
-                                                    RoundedRectangle(cornerRadius: 12)
-                                                        .frame(width: 120, height: 4)
+                                                    RoundedRectangle(cornerRadius: 2)
+                                                        .frame(width: 44, height: 4)
+                                                        .foregroundStyle(.gray200)
                                                         .padding(.vertical, 5)
                                                 }
                                                 .gesture(
@@ -598,17 +600,19 @@ private struct MainOriginalView: View {
                                                     mainPDFViewModel.isPaperViewFirst.toggle()
                                                 }
                                             },
-                                            isVertical: true
+                                            isVertical: true,
+                                            dynamicHeight: $dynamicHeight
                                         )
                                         
                                         VStack(spacing: 0) {
                                             Rectangle()
-                                                .frame(width: 120, height: 20)
-                                                .foregroundStyle(.clear)
+                                                .frame(height: 8)
+                                                .foregroundStyle(.gray550)
                                                 .contentShape(Rectangle())
                                                 .overlay {
-                                                    RoundedRectangle(cornerRadius: 12)
-                                                        .frame(width: 120, height: 4)
+                                                    RoundedRectangle(cornerRadius: 2)
+                                                        .frame(width: 44, height: 4)
+                                                        .foregroundStyle(.gray200)
                                                         .padding(.vertical, 5)
                                                 }
                                                 .gesture(
@@ -653,18 +657,20 @@ private struct MainOriginalView: View {
                                                 mainPDFViewModel.isPaperViewFirst.toggle()
                                             }
                                         },
-                                        isVertical: false
+                                        isVertical: false,
+                                        dynamicHeight: $dynamicHeight
                                     )
                                     
                                     HStack(spacing: 0) {
                                         Spacer()
                                         Rectangle()
-                                            .frame(width: 20, height: 120)
-                                            .foregroundStyle(.clear)
+                                            .frame(width: 8)
+                                            .foregroundStyle(.gray550)
                                             .contentShape(Rectangle())
                                             .overlay {
                                                 RoundedRectangle(cornerRadius: 12)
-                                                    .frame(width: 4, height: 120)
+                                                    .frame(width: 4, height: 44)
+                                                    .foregroundStyle(.gray200)
                                                     .padding(.horizontal, 5)
                                             }
                                             .gesture(
@@ -702,17 +708,19 @@ private struct MainOriginalView: View {
                                                 mainPDFViewModel.isPaperViewFirst.toggle()
                                             }
                                         },
-                                        isVertical: false
+                                        isVertical: false,
+                                        dynamicHeight: $dynamicHeight
                                     )
                                     
                                     HStack(spacing: 0) {
                                         Rectangle()
-                                            .frame(width: 20, height: 120)
-                                            .foregroundStyle(.clear)
+                                            .frame(width: 8)
+                                            .foregroundStyle(.gray550)
                                             .contentShape(Rectangle())
                                             .overlay {
                                                 RoundedRectangle(cornerRadius: 12)
-                                                    .frame(width: 4, height: 120)
+                                                    .frame(width: 4, height: 44)
+                                                    .foregroundStyle(.gray200)
                                                     .padding(.horizontal, 5)
                                             }
                                             .gesture(

--- a/Presentation/OriginalPaper/Floating/FloatingSplitView.swift
+++ b/Presentation/OriginalPaper/Floating/FloatingSplitView.swift
@@ -237,7 +237,7 @@ struct FloatingSplitView: View {
                             }
                         }
                     }
-                    .frame(height: isVertical ? geometry.size.height * 0.2 : geometry.size.height * 0.3)
+                    .frame(height: isVertical ? geometry.size.height * 0.3 : geometry.size.height * 0.2)
                 }
             }
             .background(.gray100)

--- a/Presentation/OriginalPaper/Floating/FloatingSplitView.swift
+++ b/Presentation/OriginalPaper/Floating/FloatingSplitView.swift
@@ -35,8 +35,9 @@ struct FloatingSplitView: View {
     let isVertical: Bool
     
     @State private var isSavedLocation: Bool = false
+    @Binding private var dynamicHeight: CGFloat
     
-    init(id: UUID, documentID: String, document: PDFDocument, head: String, isFigSelected: Bool, isCollectionSelected: Bool, onSelect: @escaping () -> Void, isVertical: Bool) {
+    init(id: UUID, documentID: String, document: PDFDocument, head: String, isFigSelected: Bool, isCollectionSelected: Bool, onSelect: @escaping () -> Void, isVertical: Bool, dynamicHeight: Binding<CGFloat>) {
         self.document = document
         _observableDocument = ObservedObject(wrappedValue: ObservableDocument(document: document))
         
@@ -47,6 +48,7 @@ struct FloatingSplitView: View {
         self.isCollectionSelected = isCollectionSelected
         self.onSelect = onSelect
         self.isVertical = isVertical
+        self._dynamicHeight = dynamicHeight
     }
     
     var body: some View {
@@ -167,7 +169,7 @@ struct FloatingSplitView: View {
                 }
                 
                 
-                if isFigSelected || isCollectionSelected {
+                if (isFigSelected || isCollectionSelected) && !(isVertical && dynamicHeight <= 400) {
                     Rectangle()
                         .frame(height: 1)
                         .foregroundStyle(.gray300)

--- a/Presentation/OriginalPaper/Floating/FloatingView.swift
+++ b/Presentation/OriginalPaper/Floating/FloatingView.swift
@@ -151,7 +151,7 @@ struct FloatingView: View {
                     DragGesture()
                         .onChanged { value in
                             // 최대 크기 제한 850 + 최소 크기 제한 300
-                            let newWidth = max(min(viewWidth + value.translation.width, 850), 200)
+                            let newWidth = max(min(viewWidth + value.translation.width, 850), 500)
                             self.viewWidth = newWidth
                         }
                 )

--- a/Presentation/OriginalPaper/Floating/FloatingViewModel.swift
+++ b/Presentation/OriginalPaper/Floating/FloatingViewModel.swift
@@ -51,7 +51,7 @@ class FloatingViewModel: ObservableObject {
                 isSelected: true,
                 viewOffset: CGSize(width: 0, height: 0),
                 lastOffset: CGSize(width: 0, height: 0),
-                viewWidth: 300,
+                viewWidth: 500,
                 isInSplitMode: false,
                 isFigure: isFigure
             )

--- a/Presentation/OriginalPaper/Floating/FloatingViewsContainer.swift
+++ b/Presentation/OriginalPaper/Floating/FloatingViewsContainer.swift
@@ -45,7 +45,7 @@ struct FloatingViewsContainer: View {
                             get: { droppedFigure.viewWidth },
                             set: { newValue in
                                 if let index = floatingViewModel.droppedFigures.firstIndex(where: { $0.id == droppedFigure.id }) {
-                                    floatingViewModel.droppedFigures[index].viewWidth = max(newValue, 200)
+                                    floatingViewModel.droppedFigures[index].viewWidth = max(newValue, 500)
                                 }
                             }
                         )

--- a/Presentation/OriginalPaper/Index/IndexView.swift
+++ b/Presentation/OriginalPaper/Index/IndexView.swift
@@ -19,7 +19,7 @@ struct IndexView: View {
         ScrollView {
             VStack(alignment: .leading) {
                 if indexViewModel.tableItems.isEmpty {
-                    Text("개요가 있으면,\n여기에 표시됩니다")
+                    Text("목차가 있으면,\n여기에 표시됩니다")
                         .multilineTextAlignment(.center)
                         .reazyFont(.body3)
                         .foregroundStyle(.gray600)

--- a/Presentation/OriginalPaper/Menus/FigureList/Collection/CollectionView.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Collection/CollectionView.swift
@@ -40,7 +40,7 @@ struct CollectionView: View {
                                         isSelected: true,
                                         viewOffset: CGSize(width: 0, height: 0),
                                         lastOffset: CGSize(width: 0, height: 0),
-                                        viewWidth: 300,
+                                        viewWidth: 500,
                                         isInSplitMode: true,
                                         isFigure: false
                                     )

--- a/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureView.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureView.swift
@@ -141,7 +141,7 @@ private struct FigureCompleteView: View {
                                 isSelected: true,
                                 viewOffset: CGSize(width: 0, height: 0),
                                 lastOffset: CGSize(width: 0, height: 0),
-                                viewWidth: 300,
+                                viewWidth: 500,
                                 isInSplitMode: true,
                                 isFigure: true
                             )

--- a/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
@@ -67,7 +67,7 @@ extension FocusFigureViewModel {
         if self.isStartFetching { return }
         defer { self.isStartFetching = false }
         
-        var paperInfo = self.focusFigureUseCase.pdfSharedData.paperInfo
+        let paperInfo = self.focusFigureUseCase.pdfSharedData.paperInfo
         let document = self.focusFigureUseCase.pdfSharedData.document
         
         if let paper = paperInfo?.isFigureSaved, !paper { return }

--- a/Presentation/OriginalPaper/Menus/MenuView.swift
+++ b/Presentation/OriginalPaper/Menus/MenuView.swift
@@ -9,16 +9,16 @@ import SwiftUI
 
 struct MenuView: View {
     @EnvironmentObject private var mainPDFViewModel: MainPDFViewModel
-    @State private var selectedTab: String = "개요"
+    @State private var selectedTab: String = "목차"
 
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
-                TabButton(title: "개요", selectedTab: $selectedTab)
+                TabButton(title: "목차", selectedTab: $selectedTab)
                 TabButton(title: "페이지", selectedTab: $selectedTab)
             }
 
-            if selectedTab == "개요" {
+            if selectedTab == "목차" {
                 IndexView()
             } else {
                 PageListView()

--- a/Presentation/OriginalPaper/Menus/SearchList/SearchView.swift
+++ b/Presentation/OriginalPaper/Menus/SearchList/SearchView.swift
@@ -33,13 +33,15 @@ struct SearchView: View {
                             viewModel: viewModel,
                             isTapGesture: $isTapGesture,
                             selectedIndex: $selectedIndex)
+                        .padding(.top, 3)
+                        .padding(.bottom, 10)
                     }
                     
                     
                     if viewModel.isNoMatchTextVisible {
                         Spacer()
                         Text("일치하는 결과 없음")
-                            .font(.custom(ReazyFontType.pretendardRegularFont, size: 12))
+                            .reazyFont(.text5)
                             .foregroundStyle(.gray800)
                     }
                     
@@ -122,8 +124,8 @@ private struct SearchTextFieldView: View {
                 TextField("검색", text: $viewModel.searchText)
                     .padding(.leading, 4)
                     .padding(.trailing, 10)
-                    .foregroundStyle(.gray800)
-                    .font(.custom(ReazyFontType.pretendardRegularFont, size: 14))
+                    .foregroundStyle(.gray600)
+                    .reazyFont(.button3)
                     .focused($focus)
             }
         }
@@ -154,9 +156,7 @@ private struct SearchTopView: View {
                 previousResult()
             } label: {
                 Image(systemName: "chevron.left")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 9)
+                    .font(.system(size: 12))
                     .foregroundStyle(.gray700)
             }
             .padding(.trailing, 16)
@@ -165,9 +165,7 @@ private struct SearchTopView: View {
                 nextResult()
             } label: {
                 Image(systemName: "chevron.right")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 9)
+                    .font(.system(size: 12))
                     .foregroundStyle(.gray700)
             }
         }


### PR DESCRIPTION
## 변경 사항
- [ ] SplitView 디자인 최종 시안을 적용하였습니다
- [ ] 세로 화면에서 SplitView를 조정하게 되면 FigureView가 영역을 벗어나게 되는 오류를 수정하였습니다 : 일정 길이 이상 작아지게 되면 FigureView가 보이지 않도록 조정하였습니다
_~✏️ 지금은 분명한 숫자로 지정해 뒀는데, 버그 수정하게 된다면 반응형으로 수정해 보겠습니다!~_
- [ ] 세로 SplitView에서 Figure가 상단에 있을 때, 하단의 ScrollView와 터치 영역이 겹쳐 조정이 잘 되지 않는 오류를 수정하였습니다
``` Swift
.highPriorityGesture(
    DragGesture()
        .onChanged { value in
            let newHeight = dynamicHeight + value.translation.height
            dynamicHeight = max(50, min(newHeight, geometry.size.height - 50))
        }
)
```

이처럼 `highPriorityGesture`를 사용하면, 이 Gesture의 우선순위가 가장 높아 원하는 DragGesture가 우선적으로 반응합니다!

## 스크린샷 or 영상 링크

https://github.com/user-attachments/assets/14a058c2-81e0-4f95-b55a-11df1885a895

https://github.com/user-attachments/assets/73781414-0abe-4197-b051-99c5ff71a112


~이게 잘 먹는 건가 싶으실 수 있지만... 아예 안 먹었었습니다,~
~그래도 나름 첫 타 잘 잡으면 진심 잘 됨 함 해 보세여~

## 팀원에게 전달할 사항(Optional)
또 반영할 사항이 있다면 말씀해 주세요!

![image](https://github.com/user-attachments/assets/e7f4a7a0-a9fb-4730-a2fa-de6be62ae290)

close #441 

