### PR TITLE
[#425] 코멘트 linecap 버그 수정

### DIFF
--- a/Presentation/OriginalPaper/Menus/Comment/ViewModel/CommentViewModel.swift
+++ b/Presentation/OriginalPaper/Menus/Comment/ViewModel/CommentViewModel.swift
@@ -473,8 +473,8 @@ extension CommentViewModel {
             context.setStrokeColor(UIColor.point4.withAlphaComponent(0.4).cgColor)
             
             // 라인 그리기
-            let start = CGPoint(x: bounds.minX, y: bounds.minY)
-            let end = CGPoint(x: bounds.maxX, y: bounds.minY)
+            let start = CGPoint(x: bounds.minX + 0.4, y: bounds.minY + 0.4)
+            let end = CGPoint(x: bounds.maxX - 0.4, y: bounds.minY + 0.4)
             
             context.move(to: start)
             context.addLine(to: end)
@@ -492,28 +492,25 @@ extension CommentViewModel {
                 var bounds = selection.bounds
                 
                 /// 밑줄 높이 조정
+                let adjustment: CGFloat = -0.4
                 let originalBoundsHeight = bounds.size.height
                 
                 switch originalBoundsHeight {
                 case 18... :
                     bounds.size.height *= 0.45
-                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3
                 case 16..<18 :
                     bounds.size.height *= 0.5
-                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3
                 case 11..<16 :
                     bounds.size.height *= 0.55
-                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3
                 case 10..<11 :
                     bounds.size.height *= 0.6
-                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3
                 case 9..<10 :
                     bounds.size.height *= 0.7
-                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3
                 default :
-                    bounds.size.height *= 0.8                                                   // bounds 높이 조정하기
-                    bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3          // 줄인 높인만큼 y축 이동
+                    bounds.size.height *= 0.8           // bounds 높이 조정하기
                 }
+                
+                bounds.origin.y += (originalBoundsHeight - bounds.size.height) / 3 + adjustment
                 
                 let underline = lineAnnotation(bounds: bounds, forType: .line, withProperties: nil)
                 


### PR DESCRIPTION
## 변경 사항
- [ ] 코멘트 라인 캡 모양 둥글게 안나오는 버그 수정했어요
보니까 bouds 값에 영향을 받는 거 같아서 루시드가 써준 코드에 `adjustment` 추가해서 범위 늘려줬습니다.
그리고 반복되는 코드는 한번에 묶어서 정리했어용~

## 스크린샷 or 영상 링크
![Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-01-23 at 23 48 58](https://github.com/user-attachments/assets/9423f738-5919-46cf-aa9f-10799df9a0ec)

일단 제가 보기에 둥글긴 한데 .. 확인 함 부탁드립니다

