### PR TITLE
[Chore] Floating Split View 최소 크기 및 디자인 오류 수정

### DIFF
--- a/Presentation/MainPDF/MainPDFView.swift
+++ b/Presentation/MainPDF/MainPDFView.swift
@@ -564,7 +564,7 @@ private struct MainOriginalView: View {
                                                     DragGesture()
                                                         .onChanged { value in
                                                             let newHeight = dynamicHeight + value.translation.height
-                                                            dynamicHeight = max(50, min(newHeight, geometry.size.height - 50))
+                                                            dynamicHeight = max(geometry.size.height * 2 / 7, min(newHeight, geometry.size.height - 50))
                                                         }
                                                 )
                                         }
@@ -619,7 +619,7 @@ private struct MainOriginalView: View {
                                                     DragGesture()
                                                         .onChanged { value in
                                                             let newHeight = dynamicHeight - value.translation.height
-                                                            dynamicHeight = max(50, min(newHeight, geometry.size.height - 50))
+                                                            dynamicHeight = max(geometry.size.height * 2 / 7, min(newHeight, geometry.size.height - 50))
                                                         }
                                                 )
                                             Spacer()
@@ -677,7 +677,7 @@ private struct MainOriginalView: View {
                                                 DragGesture()
                                                     .onChanged { value in
                                                         let newWidth = dynamicWidth + value.translation.width
-                                                        dynamicWidth = max(50, min(newWidth, geometry.size.width - 50))
+                                                        dynamicWidth = max(geometry.size.width * 2 / 7, min(newWidth, geometry.size.width - 50))
                                                     }
                                             )
                                     }
@@ -727,7 +727,7 @@ private struct MainOriginalView: View {
                                                 DragGesture()
                                                     .onChanged { value in
                                                         let newWidth = dynamicWidth - value.translation.width
-                                                        dynamicWidth = max(50, min(newWidth, geometry.size.width - 50))
+                                                        dynamicWidth = max(geometry.size.width * 2 / 7, min(newWidth, geometry.size.width - 50))
                                                     }
                                             )
                                         Spacer()

--- a/Presentation/OriginalPaper/Floating/FloatingSplitView.swift
+++ b/Presentation/OriginalPaper/Floating/FloatingSplitView.swift
@@ -76,6 +76,32 @@ struct FloatingSplitView: View {
                         
                         Spacer()
                         
+                        Button(action: {
+                            floatingViewModel.moveToPreviousFigure(focusFigureViewModel: focusFigureViewModel, observableDocument: observableDocument)
+                        }, label: {
+                            Image(systemName: "chevron.left")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundStyle(.gray600)
+                        })
+                        .padding(.leading, 24)
+                        
+                        Text(head)
+                            .reazyFont(.text1)
+                            .foregroundStyle(.gray800)
+                            .lineLimit(1)
+                            .padding(.horizontal, 24)
+                        
+                        Button(action: {
+                            floatingViewModel.moveToNextFigure(focusFigureViewModel: focusFigureViewModel, observableDocument: observableDocument)
+                        }, label: {
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundStyle(.gray600)
+                        })
+                        .padding(.trailing, 24)
+                        
+                        Spacer()
+                        
                         Menu {
                             Button(action: {
                                 self.focusFigureViewModel.selectedID = id
@@ -106,33 +132,6 @@ struct FloatingSplitView: View {
                         })
                         .padding(.leading, 24)
                         .padding(.trailing, 20)
-                    }
-                    
-                    HStack(spacing: 0) {
-                        Spacer()
-                        
-                        Button(action: {
-                            floatingViewModel.moveToPreviousFigure(focusFigureViewModel: focusFigureViewModel, observableDocument: observableDocument)
-                        }, label: {
-                            Image(systemName: "chevron.left")
-                                .font(.system(size: 14, weight: .medium))
-                                .foregroundStyle(.gray600)
-                        })
-                        
-                        Text(head)
-                            .reazyFont(.text1)
-                            .foregroundStyle(.gray800)
-                            .padding(.horizontal, 24)
-                        
-                        Button(action: {
-                            floatingViewModel.moveToNextFigure(focusFigureViewModel: focusFigureViewModel, observableDocument: observableDocument)
-                        }, label: {
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 14, weight: .medium))
-                                .foregroundStyle(.gray600)
-                        })
-                        
-                        Spacer()
                     }
                 }
                 .padding(.vertical, 12)


### PR DESCRIPTION
## 변경 사항
- [ ] 50으로 지정되어 있던 SplitView 최소 크기를 화면 크기의 2/7 비율로 조정하였습니다! (가장 버튼 배열이 아름다운 정도,)
- [ ]  FloatingSplitView의 상단바 내 버튼이 ZStack으로 겹쳐져 있어 Figure의 이름이 길어지면 화면을 줄였을 때 텍스트가 버튼 영역을 침범하는 것을 확인하였습니다! 현재 대칭이 잡혀 있는 상황이라 하나의 HStack으로 통합하여 이 문제를 해결했어용.

## 스크린샷 or 영상 링크
### ✨ 가로 모드에서 SplitView의 최소 크기와 보여지는 화면은 아래와 같습니다
![image](https://github.com/user-attachments/assets/19220ff4-8377-49e3-9dac-39020fcbbaa1)
### ✨ 세로 모드에서 SplitView의 최소 크기와 보여지는 화면은 아래와 같습니다
<img src="https://github.com/user-attachments/assets/4ff6aac5-c93f-4887-b4b6-edad576bab30" width=500/>


## 팀원에게 전달할 사항(Optional)
> 세로에서 SplitView가 하단에 있을 때 비주얼적으로 뭔가 요상한 면이 있어서 그건 제가 내일 확인해서 다음 업데이트 때 반영할 수 있도록 하겠습니당. 그리고 FloatingView 최소 조정 사이즈도 확인할게요!

졸리내요.

![image](https://github.com/user-attachments/assets/c21eb664-6970-49e8-95a1-a3a09cac8388)


close #447 
