### PR TITLE
[Feat] 홈 검색 뷰 데이터 연결

### DIFF
--- a/Data/CoreData/Repositories/ButtonGroupDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/ButtonGroupDataRepositoryImpl.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreData
 import UIKit
 
-class ButtonGroupDataRepositoryImpl: ButtonGroupDataRepository {
+final class ButtonGroupDataRepositoryImpl: ButtonGroupDataRepository {
     private let container: NSPersistentContainer = PersistantContainer.shared.container
     
     func loadButtonGroup(for pdfID: UUID) -> Result<[ButtonGroup], any Error> {

--- a/Data/CoreData/Repositories/CollectionDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/CollectionDataRepositoryImpl.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CoreData
 
-class CollectionDataRepositoryImpl: CollectionDataRepository {
+final class CollectionDataRepositoryImpl: CollectionDataRepository {
     private let container: NSPersistentContainer = PersistantContainer.shared.container
     
     func loadCollectionData(for pdfID: UUID) -> Result<[Figure], any Error> {

--- a/Data/CoreData/Repositories/CommentDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/CommentDataRepositoryImpl.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreData
 import UIKit
 
-class CommentDataRepositoryImpl: CommentDataRepository {
+final class CommentDataRepositoryImpl: CommentDataRepository {
     private let container: NSPersistentContainer = PersistantContainer.shared.container
     
     func loadCommentData(for pdfID: UUID) -> Result<[Comment], Error> {

--- a/Data/CoreData/Repositories/FigureDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/FigureDataRepositoryImpl.swift
@@ -9,7 +9,7 @@ import Foundation
 import CoreData
 import UIKit
 
-class FigureDataRepositoryImpl: FigureDataRepository {
+final class FigureDataRepositoryImpl: FigureDataRepository {
     private let container: NSPersistentContainer = PersistantContainer.shared.container
     
     func loadFigureData(for pdfID: UUID) -> Result<[Figure], any Error> {

--- a/Data/CoreData/Repositories/FolderDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/FolderDataRepositoryImpl.swift
@@ -10,7 +10,7 @@ import CoreData
 import SwiftUI
 import UIKit
 
-class FolderDataRepositoryImpl: FolderDataRepository {
+final class FolderDataRepositoryImpl: FolderDataRepository {
     private let container: NSPersistentContainer = PersistantContainer.shared.container
     
     func loadFolders() -> Result<[Folder], any Error> {

--- a/Data/CoreData/Repositories/PaperDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/PaperDataRepositoryImpl.swift
@@ -10,7 +10,7 @@ import CoreData
 import SwiftUI
 import UIKit
 
-class PaperDataRepositoryImpl: PaperDataRepository {
+final class PaperDataRepositoryImpl: PaperDataRepository {
     private let container: NSPersistentContainer = PersistantContainer.shared.container
     
     // 저장된 PDF 정보를 모두 불러옵니다

--- a/Data/CoreData/Repositories/PaperDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/PaperDataRepositoryImpl.swift
@@ -190,6 +190,7 @@ final class PaperDataRepositoryImpl: PaperDataRepository {
                 }
                 
                 newPaperData.id = info.id
+                newPaperData.title = info.title
                 newPaperData.isFavorite = info.isFavorite
                 newPaperData.isFigureSaved = info.isFigureSaved
                 newPaperData.lastModifiedDate = info.lastModifiedDate

--- a/Data/CoreData/Repositories/TagDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/TagDataRepositoryImpl.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CoreData
 
-class TagDataRepositoryImpl: TagDataRepository {
+final class TagDataRepositoryImpl: TagDataRepository {
     private let container: NSPersistentContainer = PersistantContainer.shared.container
     
     func fetchAllTags() -> Result<[Tag], any Error> {

--- a/DesignSystem/Views/RenamePaperTitleView.swift
+++ b/DesignSystem/Views/RenamePaperTitleView.swift
@@ -1,0 +1,117 @@
+//
+//  RenamePaperTitleView.swift
+//  Reazy
+//
+//  Created by 문인범 on 2/19/25.
+//
+
+import SwiftUI
+
+
+/**
+ 논문 이름 재설정 View
+ */
+public struct RenamePaperTitleView: View {
+    let paperInfo: PaperInfo
+    let cancelAction: () -> Void
+    let completeAction: (String) -> Void
+    
+    @State private var text: String
+    @FocusState private var isTextFieldFocused: Bool
+    
+    init(
+        paperInfo: PaperInfo,
+        cancelAction: @escaping () -> Void,
+        completeAction: @escaping (String) -> Void
+    ) {
+        self.paperInfo = paperInfo
+        self.cancelAction = cancelAction
+        self.completeAction = completeAction
+        self.text = paperInfo.title
+    }
+    
+    public var body: some View {
+        ZStack {
+            Color.black
+                .opacity(0.5)
+                .ignoresSafeArea()
+            
+            VStack {
+                HStack {
+                    Button {
+                        cancelAction()
+                        isTextFieldFocused = false
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 18))
+                    }
+                    .foregroundStyle(.gray100)
+                    .padding(28)
+                    
+                    Spacer()
+                    
+                    Button(action: {
+                        completeAction(text)
+                        isTextFieldFocused = false
+                    }) {
+                        RoundedRectangle(cornerRadius: 20)
+                            .stroke(.gray100, lineWidth: 1)
+                            .frame(width: 68, height: 36)
+                            .overlay {
+                                Text("완료")
+                                    .reazyFont(.button1)
+                                    .foregroundStyle(.gray100)
+                            }
+                    }
+                    .padding(28)
+                }
+                
+                Spacer()
+            }
+            HStack(spacing: 54) {
+                Image(uiImage: .init(data: paperInfo.thumbnail)!)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 196)
+                
+                VStack(spacing: 16) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 12)
+                            .foregroundStyle(.gray100)
+                            .frame(width: 400, height: 52)
+                        
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(lineWidth: 1)
+                            .foregroundStyle(.gray400)
+                            .frame(width: 400, height: 52)
+                    }
+                    .frame(width: 400, height: 52)
+                    .overlay(alignment: .center) {
+                        TextField("제목을 입력해주세요.", text: $text, axis: .horizontal)
+                            .lineLimit(1)
+                            .padding(.horizontal, 16)
+                            .font(.custom(ReazyFontType.pretendardMediumFont, size: 16))
+                            .foregroundStyle(.gray800)
+                    }
+                    .overlay(alignment: .trailing) {
+                        if !self.text.isEmpty {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 18))
+                                .foregroundStyle(.gray600)
+                                .background(.gray100)
+                                .padding(.trailing, 10)
+                                .onTapGesture {
+                                    text = ""
+                                }
+                        }
+                    }
+                    .focused($isTextFieldFocused)
+                    
+                    Text("논문 제목을 입력해 주세요")
+                        .reazyFont(.button1)
+                        .foregroundStyle(.comment)
+                }
+            }
+        }
+    }
+}

--- a/Domain/Entities/PaperInfo.swift
+++ b/Domain/Entities/PaperInfo.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-struct PaperInfo: Identifiable {
+struct PaperInfo: Identifiable, Hashable {
     let id: UUID
     var title: String
     let thumbnail: Data

--- a/Domain/Entities/Tag.swift
+++ b/Domain/Entities/Tag.swift
@@ -7,12 +7,17 @@
 
 import Foundation
 
-struct Tag {
+struct Tag: DynamicCell {
     let id: UUID
     var name: String
     
     init(id: UUID = .init(), name: String) {
         self.id = id
         self.name = name
+    }
+    
+    func getCellWidth() -> CGFloat {
+        let count = self.name.count
+        return CGFloat(10 + count * 10)
     }
 }

--- a/Domain/Interfaces/DynamicCell.swift
+++ b/Domain/Interfaces/DynamicCell.swift
@@ -1,0 +1,16 @@
+//
+//  DynamicCell.swift
+//  Reazy
+//
+//  Created by 문인범 on 2/19/25.
+//
+
+import Foundation
+
+
+protocol DynamicCell: Hashable, Identifiable {
+    var id: UUID { get }
+    var name: String { get }
+    
+    func getCellWidth() -> CGFloat
+}

--- a/Domain/Interfaces/PDFSharedData.swift
+++ b/Domain/Interfaces/PDFSharedData.swift
@@ -31,6 +31,10 @@ class PDFSharedData {
             
             let document = PDFDocument(url: url)
             self.document = document
+            
+            if let originalPaper = self.paperInfo, originalPaper.id == paperInfo.id {
+                return
+            }
             self.paperInfo = paperInfo
         }
     }

--- a/Domain/Interfaces/Repositories/ButtonGroupDataRepository.swift
+++ b/Domain/Interfaces/Repositories/ButtonGroupDataRepository.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol ButtonGroupDataRepository {
+protocol ButtonGroupDataRepository: Sendable {
     /// 저장된 버튼 그룹을 불러옵니다
     func loadButtonGroup(for pdfID: UUID) -> Result<[ButtonGroup], Error>
     

--- a/Domain/Interfaces/Repositories/CollectionDataRepository.swift
+++ b/Domain/Interfaces/Repositories/CollectionDataRepository.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol CollectionDataRepository {
+protocol CollectionDataRepository: Sendable {
     /// 저장된 모아보기 데이터를 불러옵니다
     func loadCollectionData(for pdfID: UUID) -> Result<[Figure], Error>
     

--- a/Domain/Interfaces/Repositories/CommentDataRepository.swift
+++ b/Domain/Interfaces/Repositories/CommentDataRepository.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol CommentDataRepository {
+protocol CommentDataRepository: Sendable {
     /// 코멘트 기록을 불러옵니다
     func loadCommentData(for pdfID: UUID) -> Result<[Comment], Error>
     

--- a/Domain/Interfaces/Repositories/FigureDataRepository.swift
+++ b/Domain/Interfaces/Repositories/FigureDataRepository.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol FigureDataRepository {
+protocol FigureDataRepository: Sendable {
     /// 저장된 FigureData를 불러옵니다
     func loadFigureData(for pdfID: UUID) -> Result<[Figure], Error>
     

--- a/Domain/Interfaces/Repositories/FolderDataRepository.swift
+++ b/Domain/Interfaces/Repositories/FolderDataRepository.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol FolderDataRepository {
+protocol FolderDataRepository: Sendable {
     /// 저장된 폴더 정보를 모두 불러옵니다
     func loadFolders() -> Result<[Folder], Error>
     

--- a/Domain/Interfaces/Repositories/TagDataRepository.swift
+++ b/Domain/Interfaces/Repositories/TagDataRepository.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol TagDataRepository {
+protocol TagDataRepository: Sendable {
     // 모든 태그 데이터를 가져옵니다
     func fetchAllTags() -> Result<[Tag], Error>
     

--- a/Domain/UseCases/HomeSearchUseCase.swift
+++ b/Domain/UseCases/HomeSearchUseCase.swift
@@ -11,6 +11,9 @@ import Foundation
 protocol HomeSearchUseCase: Sendable {
     func fetchSearchList(target: SearchTarget, matches: String) -> Result<[PaperInfo], any Error>
     func fetchByTagId(tagId: UUID) -> Result<[PaperInfo], any Error>
+    
+    @discardableResult
+    func editPDF(_ info: PaperInfo) -> Result<VoidResponse, any Error>
 }
 
 enum SearchTarget {
@@ -51,6 +54,9 @@ final class DefaultHomeSearchUseCase: HomeSearchUseCase {
         return .failure(NSError())
     }
     
+    func editPDF(_ info: PaperInfo) -> Result<VoidResponse, any Error> {
+        self.paperDataRepository.editPDFInfo(info)
+    }
     
     private func fetchPapersByTagName(_ tagName: String) -> [PaperInfo] {
         let response = tagDataRepository.fetchAllTags()

--- a/Domain/UseCases/HomeSearchUseCase.swift
+++ b/Domain/UseCases/HomeSearchUseCase.swift
@@ -38,7 +38,7 @@ final class DefaultHomeSearchUseCase: HomeSearchUseCase {
             }
         case .tag:
             let papers = fetchPapersByTagName(matches)
-            return papers.isEmpty ? .failure(NSError()) : .success(papers)
+            return .success(papers)
         }
     }
     

--- a/Domain/UseCases/HomeSearchUseCase.swift
+++ b/Domain/UseCases/HomeSearchUseCase.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol HomeSearchUseCase: Sendable {
     func fetchSearchList(target: SearchTarget, matches: String) -> Result<[PaperInfo], any Error>
+    func fetchByTagId(tagId: UUID) -> Result<[PaperInfo], any Error>
 }
 
 enum SearchTarget {
@@ -40,6 +41,14 @@ final class DefaultHomeSearchUseCase: HomeSearchUseCase {
             let papers = fetchPapersByTagName(matches)
             return .success(papers)
         }
+    }
+    
+    func fetchByTagId(tagId: UUID) -> Result<[PaperInfo], any Error> {
+        let response = tagDataRepository.fetchPapersByTag(tagID: tagId)
+        if case let .success(papers) = response {
+            return .success(papers)
+        }
+        return .failure(NSError())
     }
     
     

--- a/Domain/UseCases/HomeSearchUseCase.swift
+++ b/Domain/UseCases/HomeSearchUseCase.swift
@@ -17,6 +17,9 @@ protocol HomeSearchUseCase: Sendable {
     
     @discardableResult
     func deletePDF(_ info: PaperInfo) -> Result<VoidResponse, any Error>
+    
+    @discardableResult
+    func duplicatePDF(_ info: PaperInfo) -> Result<PaperInfo, any Error>
 }
 
 enum SearchTarget {
@@ -65,6 +68,38 @@ final class DefaultHomeSearchUseCase: HomeSearchUseCase {
         self.paperDataRepository.deletePDFInfo(id: info.id)
     }
     
+    func duplicatePDF(_ info: PaperInfo) -> Result<PaperInfo, any Error> {
+        var isStale = false
+        
+        do {
+            let originalUrl = try URL.init(resolvingBookmarkData: info.url, bookmarkDataIsStale: &isStale)
+            
+            if let (data, url) = try self.savePDFIntoDirectory(url: originalUrl, isSample: false) {
+                
+                let newPaperInfo = PaperInfo(
+                    title: url.deletingPathExtension().lastPathComponent,
+                    thumbnail: info.thumbnail,
+                    url: data,
+                    focusURL: info.focusURL,
+                    lastModifiedDate: Date(),
+                    isFavorite: info.isFavorite,
+                    isFigureSaved: info.isFigureSaved,
+                    folderID: info.folderID)
+                
+                self.paperDataRepository.duplicatePDFInfo(id: info.id, info: newPaperInfo)
+                return .success(newPaperInfo)
+            }
+            
+            return .failure(PDFUploadError.fileNameDuplication)
+        } catch {
+            return .failure(PDFUploadError.fileNameDuplication)
+        }
+    }
+}
+
+
+
+extension DefaultHomeSearchUseCase {
     private func fetchPapersByTagName(_ tagName: String) -> [PaperInfo] {
         let response = tagDataRepository.fetchAllTags()
         if case let .success(tags) = response {
@@ -80,6 +115,60 @@ final class DefaultHomeSearchUseCase: HomeSearchUseCase {
             return papers
         }
         return []
+    }
+    
+    internal func savePDFIntoDirectory(url: URL, isSample: Bool) throws -> (Data, URL)? {
+        do {
+            let manager = FileManager.default
+            let documentURL = manager.urls(for: .documentDirectory, in: .userDomainMask).first!
+            let fileURL = documentURL.appending(path: url.lastPathComponent)
+                        
+            let _ = url.startAccessingSecurityScopedResource()
+            defer { url.stopAccessingSecurityScopedResource() }
+            
+            var error: NSError?
+            
+            // 업로드 전 로컬에 다운로드 진행
+            NSFileCoordinator().coordinate(readingItemAt: url, options: .forUploading, error: &error) { _ in
+//                print("coordinated URL: \(cloudURL)")
+            }
+            
+            if let _ = try? Data(contentsOf: fileURL) {
+                var dupNum = 1
+                
+                
+                var lastComponent = url.lastPathComponent.split(separator: ".")
+                lastComponent.removeLast()
+                
+                
+                while dupNum < 100 {
+                    let tempURL = documentURL.appending(path: lastComponent.joined() + "(\(dupNum)).pdf")
+                    
+                    guard let _ = try? Data(contentsOf: tempURL) else {
+                        try manager.copyItem(at: url, to: tempURL)
+                        return try (tempURL.bookmarkData(options: .minimalBookmark), tempURL)
+                    }
+                    
+                    if dupNum == 99 {
+                        throw PDFUploadError.fileNameDuplication
+                    }
+                    
+                    dupNum += 1
+                }
+                
+                
+            } else {
+                try manager.copyItem(at: url, to: fileURL)
+            }
+            
+            let urlData = try fileURL.bookmarkData(options: .minimalBookmark)
+            
+            return (urlData, fileURL)
+        } catch {
+            print("error copying file: \(error)")
+        }
+        
+        return nil
     }
 }
 

--- a/Domain/UseCases/HomeSearchUseCase.swift
+++ b/Domain/UseCases/HomeSearchUseCase.swift
@@ -14,6 +14,9 @@ protocol HomeSearchUseCase: Sendable {
     
     @discardableResult
     func editPDF(_ info: PaperInfo) -> Result<VoidResponse, any Error>
+    
+    @discardableResult
+    func deletePDF(_ info: PaperInfo) -> Result<VoidResponse, any Error>
 }
 
 enum SearchTarget {
@@ -56,6 +59,10 @@ final class DefaultHomeSearchUseCase: HomeSearchUseCase {
     
     func editPDF(_ info: PaperInfo) -> Result<VoidResponse, any Error> {
         self.paperDataRepository.editPDFInfo(info)
+    }
+    
+    func deletePDF(_ info: PaperInfo) -> Result<VoidResponse, any Error> {
+        self.paperDataRepository.deletePDFInfo(id: info.id)
     }
     
     private func fetchPapersByTagName(_ tagName: String) -> [PaperInfo] {

--- a/Domain/UseCases/HomeSearchUseCase.swift
+++ b/Domain/UseCases/HomeSearchUseCase.swift
@@ -19,9 +19,11 @@ enum SearchTarget {
 
 final class DefaultHomeSearchUseCase: HomeSearchUseCase {
     private let paperDataRepository: PaperDataRepository
+    private let tagDataRepository: TagDataRepository
     
-    init(paperDataRepository: PaperDataRepository) {
+    init(paperDataRepository: PaperDataRepository, tagDataRepository: TagDataRepository) {
         self.paperDataRepository = paperDataRepository
+        self.tagDataRepository = tagDataRepository
     }
     
     func fetchSearchList(target: SearchTarget, matches: String) -> Result<[PaperInfo], any Error> {
@@ -35,9 +37,27 @@ final class DefaultHomeSearchUseCase: HomeSearchUseCase {
                 return .failure(NSError())
             }
         case .tag:
-            // TODO: 태그 검색 기능 구현
-            return .failure(NSError())
+            let papers = fetchPapersByTagName(matches)
+            return papers.isEmpty ? .failure(NSError()) : .success(papers)
         }
+    }
+    
+    
+    private func fetchPapersByTagName(_ tagName: String) -> [PaperInfo] {
+        let response = tagDataRepository.fetchAllTags()
+        if case let .success(tags) = response {
+            let result = tags.filter { $0.name == tagName }
+            
+            if result.isEmpty {
+                return []
+            }
+            
+            let paperTagResponse = tagDataRepository.fetchPapersByTag(tagID: result.first!.id)
+            guard case let .success(papers) = paperTagResponse else { return [] }
+            
+            return papers
+        }
+        return []
     }
 }
 

--- a/Domain/UseCases/HomeViewUseCase.swift
+++ b/Domain/UseCases/HomeViewUseCase.swift
@@ -97,6 +97,9 @@ class DefaultHomeViewUseCase: HomeViewUseCase {
             )
             
             self.paperDataRepository.savePDFInfo(paperInfo)
+            // MARK: 샘플태그 업로드 메소드
+//            self.sampleTagUpload(paperInfo.id)
+            
             return paperInfo
             
         } else {
@@ -385,5 +388,13 @@ class DefaultHomeViewUseCase: HomeViewUseCase {
         }
         
         return nil
+    }
+    
+    private func sampleTagUpload(_ paperId: UUID) {
+        let repository = PaperDataRepositoryImpl()
+        
+        let _ = repository.addTag(to: paperId, with: "reazy")
+        let _ = repository.addTag(to: paperId, with: "한국어")
+        let _ = repository.addTag(to: paperId, with: "Heat Transfer")
     }
 }

--- a/Presentation/Helper/Navigation/NavigationCoordinator.swift
+++ b/Presentation/Helper/Navigation/NavigationCoordinator.swift
@@ -57,7 +57,12 @@ final class NavigationCoordinator: CoordinatorProtocol {
                 let _ = PDFSharedData.shared.makeDocument(from: paperInfo)
                 
                 MainPDFView(
-                    pdfInfoMenuViewModel: .init(pdfInfoMenuUsecase: DefaultPDFInfoMenuUseCase(paperDataRepository: PaperDataRepositoryImpl())), mainPDFViewModel: .init(),
+                    pdfInfoMenuViewModel: .init(
+                        pdfInfoMenuUsecase: DefaultPDFInfoMenuUseCase(
+                            paperDataRepository: PaperDataRepositoryImpl()
+                        )
+                    ),
+                    mainPDFViewModel: .init(),
                     commentViewModel: .init(
                         commentService: CommentDataRepositoryImpl(),
                         buttonGroupService: ButtonGroupDataRepositoryImpl()
@@ -65,9 +70,12 @@ final class NavigationCoordinator: CoordinatorProtocol {
                     focusFigureViewModel: .init(
                         focusFigureUseCase:
                             DefaultFocusFigureUseCase(
-                                focusFigureRepository: FocusFigureRepositoryImpl(baseProcess: .processFulltextDocument),
+                                focusFigureRepository: FocusFigureRepositoryImpl(
+                                    baseProcess: .processFulltextDocument
+                                ),
                                 figureDataRepository: FigureDataRepositoryImpl(),
-                                collectionDataRepository: CollectionDataRepositoryImpl())
+                                collectionDataRepository: CollectionDataRepositoryImpl()
+                            )
                     ),
                     pageListViewModel: .init(pageListUseCase: DefaultPageListUseCase()),
                     searchViewModel: .init(),

--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -32,7 +32,8 @@ struct HomePDFCell<Content: View>: View {
                     
                     PaperInformationView(
                         title: paperInfo.title,
-                        date: paperInfo.lastModifiedDate
+                        date: paperInfo.lastModifiedDate,
+                        tags: paperInfo.tags
                     )
                     
                     Spacer()
@@ -78,16 +79,15 @@ private struct ThumbnailImageView: View {
 private struct PaperInformationView: View {
     let title: String
     let date: Date
+    let tags: [Tag]
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // TODO: pdf 타이틀
             Text(title)
                 .reazyFont(.text1)
                 .foregroundStyle(.gray900)
                 .padding(.top, 4)
             
-            // TODO: 수정 날짜
             Text(date.timeAgo)
                 .reazyFont(.h4)
                 .foregroundStyle(.gray600)
@@ -95,11 +95,11 @@ private struct PaperInformationView: View {
             
             Spacer()
             
-            
-            // TODO: 태그 생기면 연결
             HStack {
-                ForEach(0..<3, id: \.self) { _ in
-                    PDFTagCell(tag: TemporaryTag.init(name: "Temporary")) { }
+                ForEach(tags) { tag in
+                    PDFTagCell(tag: tag) {
+                        // TODO: 태그 탭 액션 연결
+                    }
                 }
             }
             .padding(.bottom, 22)

--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -86,6 +86,7 @@ private struct PaperInformationView: View {
             Text(title)
                 .reazyFont(.text1)
                 .foregroundStyle(.gray900)
+                .lineLimit(1)
                 .padding(.top, 4)
             
             Text(date.timeAgo)

--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 
 
-struct HomePDFCell<Content: View>: View {
+struct HomePDFCell: View {
     @State private var popover = false
     let paperInfo: PaperInfo
     
     let onTapGesture: () -> Void
     let starAction: () -> Void
     let tagAction: (UUID) -> Void
-    let ellipsisButtonView: () -> Content
+    let editAction: () -> Void
 
     
     var body: some View {
@@ -43,7 +43,10 @@ struct HomePDFCell<Content: View>: View {
                         popover.toggle()
                     }
                     .popover(isPresented: $popover, arrowEdge: .trailing) {
-                        ellipsisButtonView()
+                        EllipsisButtonView {
+                            editAction()
+                            popover.toggle()
+                        }
                     }
                 }
                 .padding(.top, 10)
@@ -134,3 +137,108 @@ private struct EllipsisView: View {
 }
 
 
+// MARK: - Epllipsis 버튼 뷰
+private struct EllipsisButtonView: View {
+    let editTitleAction: () -> Void
+    
+    // TODO: 버튼 액션 추가
+    var body: some View {
+        VStack(spacing: 0) {
+            Button {
+                editTitleAction()
+            } label: {
+                HStack {
+                    Text("제목 수정")
+                        .reazyFont(.body1)
+                    Spacer()
+                    Image(.editpencil)
+                        .resizable()
+                        .frame(width: 17, height: 17)
+                }
+            }
+            .foregroundStyle(.gray800)
+            .frame(height: 40)
+            .padding(.leading, 17)
+            .padding(.trailing, 14)
+            divider
+            
+            Button {
+                // TODO: 추후 연결 필요
+            } label: {
+                HStack {
+                    Text("태그 관리")
+                        .reazyFont(.body1)
+                    Spacer()
+                    Image(systemName: "tag")
+                        .font(.system(size: 14))
+                }
+            }
+            .foregroundStyle(.gray800)
+            .frame(height: 40)
+            .padding(.leading, 17)
+            .padding(.trailing, 14)
+            divider
+            
+            Button {
+                
+            } label: {
+                HStack {
+                    Text("복제")
+                        .reazyFont(.body1)
+                    Spacer()
+                    Image(.copyDark)
+                        .resizable()
+                        .frame(width: 17, height: 17)
+                }
+            }
+            .foregroundStyle(.gray800)
+            .frame(height: 40)
+            .padding(.leading, 17)
+            .padding(.trailing, 14)
+            divider
+            
+            Button {
+                // TODO: 추후 연결 필요
+            } label: {
+                HStack {
+                    Text("이동")
+                        .reazyFont(.body1)
+                    Spacer()
+                    Image(.move)
+                        .resizable()
+                        .frame(width: 17, height: 17)
+                }
+            }
+            .foregroundStyle(.gray800)
+            .frame(height: 40)
+            .padding(.leading, 17)
+            .padding(.trailing, 14)
+            divider
+            
+            Button {
+                
+            } label: {
+                HStack {
+                    Text("삭제")
+                        .reazyFont(.body1)
+                    Spacer()
+                    Image(.trash)
+                        .resizable()
+                        .frame(width: 17, height: 17)
+                }
+            }
+            .foregroundStyle(.pen1)
+            .frame(height: 40)
+            .padding(.leading, 17)
+            .padding(.trailing, 14)
+            
+        }
+        .frame(width: 200)
+    }
+    
+    private var divider: some View {
+        Rectangle()
+            .frame(height: 1)
+            .foregroundStyle(.primary2)
+    }
+}

--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -17,6 +17,8 @@ struct HomePDFCell: View {
     let starAction: () -> Void
     let tagAction: (UUID) -> Void
     let editAction: () -> Void
+    let copyAction: () -> Void
+    let deleteAction: () -> Void
 
     
     var body: some View {
@@ -45,6 +47,12 @@ struct HomePDFCell: View {
                     .popover(isPresented: $popover, arrowEdge: .trailing) {
                         EllipsisButtonView {
                             editAction()
+                            popover.toggle()
+                        } copyPaperAction: {
+                            copyAction()
+                            popover.toggle()
+                        } deletePaperAction: {
+                            deleteAction()
                             popover.toggle()
                         }
                     }
@@ -140,6 +148,8 @@ private struct EllipsisView: View {
 // MARK: - Epllipsis 버튼 뷰
 private struct EllipsisButtonView: View {
     let editTitleAction: () -> Void
+    let copyPaperAction: () -> Void
+    let deletePaperAction: () -> Void
     
     // TODO: 버튼 액션 추가
     var body: some View {
@@ -180,7 +190,7 @@ private struct EllipsisButtonView: View {
             divider
             
             Button {
-                
+                copyPaperAction()
             } label: {
                 HStack {
                     Text("복제")
@@ -216,7 +226,7 @@ private struct EllipsisButtonView: View {
             divider
             
             Button {
-                
+                deletePaperAction()
             } label: {
                 HStack {
                     Text("삭제")

--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -26,10 +26,9 @@ struct HomePDFCell<Content: View>: View {
                 HStack(alignment: .top, spacing: 0) {
                     ThumbnailImageView(
                         thumbnailData: paperInfo.thumbnail,
-                        isStared: paperInfo.isFavorite
-                    ) {
-                        
-                    }
+                        isStared: paperInfo.isFavorite,
+                        starAction: starAction
+                    )
                     
                     PaperInformationView(
                         title: paperInfo.title,
@@ -68,9 +67,9 @@ private struct ThumbnailImageView: View {
                 Button {
                     starAction()
                 } label: {
-                    Image(systemName: isStared ? "star.fill" :  "star")
+                    Image(systemName: isStared ? "star.fill" : "star")
                         .font(.system(size: 18))
-                        .foregroundStyle(.gray600)
+                        .foregroundStyle(isStared ? .point4 : .gray600)
                 }
                 .padding(6)
             }

--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -15,6 +15,7 @@ struct HomePDFCell<Content: View>: View {
     
     let onTapGesture: () -> Void
     let starAction: () -> Void
+    let tagAction: (UUID) -> Void
     let ellipsisButtonView: () -> Content
 
     
@@ -33,7 +34,8 @@ struct HomePDFCell<Content: View>: View {
                     PaperInformationView(
                         title: paperInfo.title,
                         date: paperInfo.lastModifiedDate,
-                        tags: paperInfo.tags
+                        tags: paperInfo.tags,
+                        tagAction: tagAction
                     )
                     
                     Spacer()
@@ -81,6 +83,8 @@ private struct PaperInformationView: View {
     let date: Date
     let tags: [Tag]
     
+    let tagAction: (UUID) -> Void
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(title)
@@ -99,7 +103,7 @@ private struct PaperInformationView: View {
             HStack {
                 ForEach(tags) { tag in
                     PDFTagCell(tag: tag) {
-                        // TODO: 태그 탭 액션 연결
+                        tagAction(tag.id)
                     }
                 }
             }

--- a/Presentation/Home/HomeSearch/Cell/PDFTagCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/PDFTagCell.swift
@@ -30,32 +30,3 @@ struct PDFTagCell<Tag: DynamicCell>: View {
         }
     }
 }
-
-#Preview {
-    HStack {
-        PDFTagCell(tag: TemporaryTag.init(name: "test")) {}
-        PDFTagCell(tag: TemporaryTag.init(name: "testfdas")) {}
-        PDFTagCell(tag: TemporaryTag.init(name: "testggggg")) {}
-        PDFTagCell(tag: TemporaryTag.init(name: "test")) {}
-        PDFTagCell(tag: TemporaryTag.init(name: "test")) {}
-    }
-}
-
-// TODO: 추후 엔티티 수정 및 폴더링 예정
-struct TemporaryTag: DynamicCell {
-    let id = UUID()
-    let name: String
-    
-    public func getCellWidth() -> CGFloat {
-        let count = self.name.count
-        return CGFloat(10 + count * 10)
-    }
-}
-
-
-protocol DynamicCell: Hashable, Identifiable {
-    var id: UUID { get }
-    var name: String { get }
-    
-    func getCellWidth() -> CGFloat
-}

--- a/Presentation/Home/HomeSearch/HomeSearchView.swift
+++ b/Presentation/Home/HomeSearch/HomeSearchView.swift
@@ -27,6 +27,9 @@ private struct HomeSearchListView: View {
     @EnvironmentObject private var navigationCoordinator: NavigationCoordinator
     @EnvironmentObject private var homeViewModel: HomeViewModel
     
+    @State private var deleteAlertPresented: Bool = false
+    @State private var selectedPaper: PaperInfo?
+    
     var body: some View {
         VStack {
             HStack(spacing: 0) {
@@ -76,9 +79,12 @@ private struct HomeSearchListView: View {
                                 // TODO: 추후 수정 필요
                                 homeSearchViewModel.tagTapped(id)
                             } editAction: {
-                                withAnimation(.easeInOut) {
-                                    homeSearchViewModel.viewStatus = .search(paperInfo)
-                                }
+                                homeSearchViewModel.editButtonTapped(paperInfo)
+                            } copyAction: {
+                                
+                            } deleteAction: {
+                                selectedPaper = paperInfo
+                                deleteAlertPresented.toggle()
                             }
                             
                             Rectangle()
@@ -89,6 +95,15 @@ private struct HomeSearchListView: View {
                     }
                 }
             }
+        }
+        .alert("정말 삭제하시겠습니까?", isPresented: $deleteAlertPresented) {
+            Button("삭제", role: .destructive) {
+                if let paperInfo = selectedPaper {
+                    homeSearchViewModel.deleteButtonTapped(paperInfo)
+                }
+            }
+            
+            Button("취소", role: .cancel, action: {})
         }
     }
 }

--- a/Presentation/Home/HomeSearch/HomeSearchView.swift
+++ b/Presentation/Home/HomeSearch/HomeSearchView.swift
@@ -31,7 +31,7 @@ private struct HomeSearchListView: View {
         VStack {
             HStack(spacing: 0) {
                 Button {
-                    homeSearchViewModel.searchTargetChanged(target: .title)
+                    homeSearchViewModel.searchTargetButtonTapped(target: .title)
                 } label: {
                     Text("제목")
                         .reazyFont(.button1)
@@ -43,7 +43,7 @@ private struct HomeSearchListView: View {
                 }
                 
                 Button {
-                    homeSearchViewModel.searchTargetChanged(target: .tag)
+                    homeSearchViewModel.searchTargetButtonTapped(target: .tag)
                 } label: {
                     Text("태그")
                         .reazyFont(.button1)
@@ -68,17 +68,18 @@ private struct HomeSearchListView: View {
                         ForEach(homeSearchViewModel.searchList) { paperInfo in
                             HomePDFCell(paperInfo: paperInfo) {
                                 // TODO: 네비게이션 push 시 Date 업데이트 필요
-                                homeSearchViewModel.setRecentSearchList()
+                                homeSearchViewModel.PaperCellTapped(paperInfo)
                                 navigationCoordinator.push(.mainPDF(paperInfo: paperInfo))
                             } starAction: {
                                 homeSearchViewModel.starButtonTapped(paperInfo)
                             } tagAction: { id in
                                 // TODO: 추후 수정 필요
                                 homeSearchViewModel.tagTapped(id)
-                            } ellipsisButtonView: {
-                                EllipsisButtonView()
+                            } editAction: {
+                                withAnimation(.easeInOut) {
+                                    homeSearchViewModel.viewStatus = .search(paperInfo)
+                                }
                             }
-                            
                             
                             Rectangle()
                                 .foregroundStyle(.primary3)
@@ -101,112 +102,6 @@ private struct SearchResultEmptyView: View {
             .reazyFont(.h5)
             .foregroundStyle(.gray550)
             .multilineTextAlignment(.center)
-    }
-}
-
-
-
-// MARK: - Epllipsis 버튼 뷰
-private struct EllipsisButtonView: View {
-    // TODO: 버튼 액션 추가
-    var body: some View {
-        VStack(spacing: 0) {
-            Button {
-                
-            } label: {
-                HStack {
-                    Text("제목 수정")
-                        .reazyFont(.body1)
-                    Spacer()
-                    Image(.editpencil)
-                        .resizable()
-                        .frame(width: 17, height: 17)
-                }
-            }
-            .foregroundStyle(.gray800)
-            .frame(height: 40)
-            .padding(.leading, 17)
-            .padding(.trailing, 14)
-            divider
-            
-            Button {
-                // TODO: 추후 연결 필요
-            } label: {
-                HStack {
-                    Text("태그 관리")
-                        .reazyFont(.body1)
-                    Spacer()
-                    Image(systemName: "tag")
-                        .font(.system(size: 14))
-                }
-            }
-            .foregroundStyle(.gray800)
-            .frame(height: 40)
-            .padding(.leading, 17)
-            .padding(.trailing, 14)
-            divider
-            
-            Button {
-                
-            } label: {
-                HStack {
-                    Text("복제")
-                        .reazyFont(.body1)
-                    Spacer()
-                    Image(.copyDark)
-                        .resizable()
-                        .frame(width: 17, height: 17)
-                }
-            }
-            .foregroundStyle(.gray800)
-            .frame(height: 40)
-            .padding(.leading, 17)
-            .padding(.trailing, 14)
-            divider
-            
-            Button {
-                // TODO: 추후 연결 필요
-            } label: {
-                HStack {
-                    Text("이동")
-                        .reazyFont(.body1)
-                    Spacer()
-                    Image(.move)
-                        .resizable()
-                        .frame(width: 17, height: 17)
-                }
-            }
-            .foregroundStyle(.gray800)
-            .frame(height: 40)
-            .padding(.leading, 17)
-            .padding(.trailing, 14)
-            divider
-            
-            Button {
-                
-            } label: {
-                HStack {
-                    Text("삭제")
-                        .reazyFont(.body1)
-                    Spacer()
-                    Image(.trash)
-                        .resizable()
-                        .frame(width: 17, height: 17)
-                }
-            }
-            .foregroundStyle(.pen1)
-            .frame(height: 40)
-            .padding(.leading, 17)
-            .padding(.trailing, 14)
-            
-        }
-        .frame(width: 200)
-    }
-    
-    private var divider: some View {
-        Rectangle()
-            .frame(height: 1)
-            .foregroundStyle(.primary2)
     }
 }
 
@@ -237,7 +132,7 @@ private struct RecentlySearchedKeywordView: View {
                     Spacer()
                     
                     Button("모두 지우기") {
-                        homeSearchViewModel.removeAllRecentSearches()
+                        homeSearchViewModel.removeAllButtonTapped()
                     }
                     .reazyFont(.text1)
                     .foregroundStyle(.primary1)

--- a/Presentation/Home/HomeSearch/HomeSearchView.swift
+++ b/Presentation/Home/HomeSearch/HomeSearchView.swift
@@ -71,7 +71,7 @@ private struct HomeSearchListView: View {
                                 homeSearchViewModel.setRecentSearchList()
                                 navigationCoordinator.push(.mainPDF(paperInfo: paperInfo))
                             } starAction: {
-                                // TODO: 즐겨찾기
+                                homeSearchViewModel.starButtonTapped(paperInfo)
                             } tagAction: { id in
                                 // TODO: 추후 수정 필요
                                 homeSearchViewModel.tagTapped(id)

--- a/Presentation/Home/HomeSearch/HomeSearchView.swift
+++ b/Presentation/Home/HomeSearch/HomeSearchView.swift
@@ -72,6 +72,9 @@ private struct HomeSearchListView: View {
                                 navigationCoordinator.push(.mainPDF(paperInfo: paperInfo))
                             } starAction: {
                                 // TODO: 즐겨찾기
+                            } tagAction: { id in
+                                // TODO: 추후 수정 필요
+                                homeSearchViewModel.tagTapped(id)
                             } ellipsisButtonView: {
                                 EllipsisButtonView()
                             }

--- a/Presentation/Home/HomeSearch/HomeSearchView.swift
+++ b/Presentation/Home/HomeSearch/HomeSearchView.swift
@@ -127,7 +127,7 @@ private struct EllipsisButtonView: View {
             divider
             
             Button {
-                
+                // TODO: 추후 연결 필요
             } label: {
                 HStack {
                     Text("태그 관리")
@@ -162,7 +162,7 @@ private struct EllipsisButtonView: View {
             divider
             
             Button {
-                
+                // TODO: 추후 연결 필요
             } label: {
                 HStack {
                     Text("이동")

--- a/Presentation/Home/HomeSearch/HomeSearchView.swift
+++ b/Presentation/Home/HomeSearch/HomeSearchView.swift
@@ -81,7 +81,7 @@ private struct HomeSearchListView: View {
                             } editAction: {
                                 homeSearchViewModel.editButtonTapped(paperInfo)
                             } copyAction: {
-                                
+                                homeSearchViewModel.copyButtonTapped(paperInfo)
                             } deleteAction: {
                                 selectedPaper = paperInfo
                                 deleteAlertPresented.toggle()

--- a/Presentation/Home/HomeSearch/HomeSearchView.swift
+++ b/Presentation/Home/HomeSearch/HomeSearchView.swift
@@ -212,17 +212,6 @@ private struct EllipsisButtonView: View {
 private struct RecentlySearchedKeywordView: View {
     @EnvironmentObject private var homeSearchViewModel: HomeSearchViewModel
     
-    // MARK: 샘플 데이터
-    let items: [TemporaryTag] = {
-        var result = [TemporaryTag]()
-        
-        for i in 0 ..< 20 {
-            result.append(.init(name: .init(repeating: "a", count: i)))
-        }
-        
-        return result
-    }()
-    
     var body: some View {
         if homeSearchViewModel.recentSearches.isEmpty {
             VStack {

--- a/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
+++ b/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
@@ -60,6 +60,15 @@ extension HomeSearchViewModel {
         
     }
     
+    public func starButtonTapped(_ paperInfo: PaperInfo) {
+        let id = paperInfo.id
+        
+        if let paperIndex = searchList.firstIndex(where: { $0.id == id }) {
+            searchList[paperIndex].isFavorite.toggle()
+            useCase.editPDF(searchList[paperIndex])
+        }
+    }
+    
     private func fetchSearchList(papers: [PaperInfo]) {
         self.searchList = papers
     }

--- a/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
+++ b/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
@@ -96,10 +96,25 @@ extension HomeSearchViewModel {
         UserDefaults.standard.recentSearches = []
         self.recentSearches.removeAll()
     }
+    
+    public func deleteButtonTapped(_ paperInfo: PaperInfo) {
+        let id = paperInfo.id
+        
+        useCase.deletePDF(paperInfo)
+        if let index = searchList.firstIndex(where: { $0.id == id }) {
+            searchList.remove(at: index)
+        }
+    }
 }
 
 // MARK: - EditingTitle 메소드
 extension HomeSearchViewModel {
+    public func editButtonTapped(_ paperInfo: PaperInfo) {
+        withAnimation(.easeInOut) {
+            viewStatus = .search(paperInfo)
+        }
+    }
+    
     public func completeButtonTappedInEditingTitle(title: String) {
         if case let .search(paper) = viewStatus,
            let index = searchList.firstIndex(of: paper) {

--- a/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
+++ b/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
@@ -14,10 +14,10 @@ final class HomeSearchViewModel: ObservableObject, Sendable {
     @Published public var searchList: [PaperInfo] = []
     @Published public var searchTarget: SearchTarget = .title
     @Published public var searchText: String = ""
-    @Published public var recentSearches: [TemporaryTag] = {
-        var result = [TemporaryTag]()
+    @Published public var recentSearches: [Tag] = {
+        var result = [Tag]()
         UserDefaults.standard.recentSearches.forEach {
-            result.append(TemporaryTag(name: $0))
+            result.append(Tag(name: $0))
         }
         return result
     }()
@@ -93,7 +93,7 @@ extension HomeSearchViewModel {
         UserDefaults.standard.recentSearches = current
         
         self.recentSearches = current.map {
-            TemporaryTag(name: $0)
+            Tag(name: $0)
         }
         
     }

--- a/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
+++ b/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-
+import SwiftUICore
 
 @MainActor
 final class HomeSearchViewModel: ObservableObject, Sendable {
@@ -21,6 +21,7 @@ final class HomeSearchViewModel: ObservableObject, Sendable {
         }
         return result
     }()
+    @Published public var viewStatus: SearchViewStatus = .normal
     
     private let useCase: HomeSearchUseCase
 
@@ -28,6 +29,11 @@ final class HomeSearchViewModel: ObservableObject, Sendable {
     
     init(useCase: HomeSearchUseCase) {
         self.useCase = useCase
+    }
+    
+    enum SearchViewStatus: Hashable {
+        case normal
+        case search(PaperInfo)
     }
 }
 
@@ -69,6 +75,52 @@ extension HomeSearchViewModel {
         }
     }
     
+    public func cellTapped(title: String) {
+        self.searchText = title
+    }
+    
+    public func searchTargetButtonTapped(target: SearchTarget) {
+        if target == searchTarget { return }
+        
+        searchTarget = target
+        self.searchList.removeAll()
+        searchPapers()
+    }
+    
+    public func PaperCellTapped(_ paperInfo: PaperInfo) {
+        setRecentSearchList()
+        editPaperDate(paperInfo)
+    }
+    
+    public func removeAllButtonTapped() {
+        UserDefaults.standard.recentSearches = []
+        self.recentSearches.removeAll()
+    }
+}
+
+// MARK: - EditingTitle 메소드
+extension HomeSearchViewModel {
+    public func completeButtonTappedInEditingTitle(title: String) {
+        if case let .search(paper) = viewStatus,
+           let index = searchList.firstIndex(of: paper) {
+            searchList[index].title = title
+            
+            useCase.editPDF(searchList[index])
+        }
+        
+        cancelButtonTappedInEditingTitle()
+    }
+    
+    public func cancelButtonTappedInEditingTitle() {
+        withAnimation(.easeInOut) {
+            viewStatus = .normal
+        }
+    }
+}
+
+
+// MARK: - Internal Method
+extension HomeSearchViewModel {
     private func fetchSearchList(papers: [PaperInfo]) {
         self.searchList = papers
     }
@@ -77,24 +129,7 @@ extension HomeSearchViewModel {
         self.isLoading = toggle
     }
     
-    public func cellTapped(title: String) {
-        self.searchText = title
-    }
-    
-    public func searchTargetChanged(target: SearchTarget) {
-        if target == searchTarget { return }
-        
-        searchTarget = target
-        self.searchList.removeAll()
-        searchPapers()
-    }
-    
-    public func removeAllRecentSearches() {
-        UserDefaults.standard.recentSearches = []
-        self.recentSearches.removeAll()
-    }
-    
-    public func setRecentSearchList() {
+    private func setRecentSearchList() {
         var current = UserDefaults.standard.recentSearches
         
         if current.count == 30 {
@@ -108,6 +143,14 @@ extension HomeSearchViewModel {
         self.recentSearches = current.map {
             Tag(name: $0)
         }
+    }
+    
+    private func editPaperDate(_ paperInfo: PaperInfo) {
+        let id = paperInfo.id
         
+        if let paperIndex = searchList.firstIndex(where: { $0.id == id }) {
+            searchList[paperIndex].lastModifiedDate = .now
+            useCase.editPDF(searchList[paperIndex])
+        }
     }
 }

--- a/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
+++ b/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
@@ -56,6 +56,10 @@ extension HomeSearchViewModel {
         }
     }
     
+    public func tagTapped(_ tagId: UUID) {
+        
+    }
+    
     private func fetchSearchList(papers: [PaperInfo]) {
         self.searchList = papers
     }

--- a/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
+++ b/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
@@ -47,17 +47,8 @@ extension HomeSearchViewModel {
         
         self.timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { [weak self] _ in
             guard let self = self else { return }
-            
             Task {
-                let response = await self.useCase.fetchSearchList(target: self.searchTarget, matches: self.searchText)
-                
-                switch response {
-                case .success(let papers):
-                    await self.fetchSearchList(papers: papers)
-                case .failure:
-                    print(#function)
-                }
-                await self.toggleIsLoading(false)
+                await self.loadSearchedList()
             }
         }
     }
@@ -105,6 +96,16 @@ extension HomeSearchViewModel {
             searchList.remove(at: index)
         }
     }
+    
+    public func copyButtonTapped(_ paperInfo: PaperInfo) {
+        let response = useCase.duplicatePDF(paperInfo)
+        
+        if case .success = response {
+            loadSearchedList()
+        } else {
+            print(#function)
+        }
+    }
 }
 
 // MARK: - EditingTitle 메소드
@@ -136,6 +137,18 @@ extension HomeSearchViewModel {
 
 // MARK: - Internal Method
 extension HomeSearchViewModel {
+    private func loadSearchedList() {
+        let response = self.useCase.fetchSearchList(target: self.searchTarget, matches: self.searchText)
+        
+        switch response {
+        case .success(let papers):
+           self.fetchSearchList(papers: papers)
+        case .failure:
+            print(#function)
+        }
+        self.toggleIsLoading(false)
+    }
+    
     private func fetchSearchList(papers: [PaperInfo]) {
         self.searchList = papers
     }

--- a/Presentation/Home/HomeView.swift
+++ b/Presentation/Home/HomeView.swift
@@ -41,7 +41,8 @@ struct HomeView: View {
     
     @StateObject private var homeSearchViewModel: HomeSearchViewModel = .init(
         useCase: DefaultHomeSearchUseCase(
-            paperDataRepository: PaperDataRepositoryImpl()
+            paperDataRepository: PaperDataRepositoryImpl(),
+            tagDataRepository: TagDataRepositoryImpl()
         )
     )
     

--- a/Presentation/Home/HomeView.swift
+++ b/Presentation/Home/HomeView.swift
@@ -30,9 +30,6 @@ struct HomeView: View {
     // 폴더 선택 변수
     @State private var selectedFolderID: UUID? = nil
     
-    // 폴더 선택 변수
-    @State private var selectedFolderID: UUID? = nil
-    
     // 폴더 추가 페이지 변수
     @State private var createFolder: Bool = false
     @State private var createMovingFolder: Bool = false

--- a/Presentation/Home/HomeView.swift
+++ b/Presentation/Home/HomeView.swift
@@ -126,12 +126,6 @@ struct HomeView: View {
                 .opacity(isEditingTitle || createFolder || isEditingFolder || isMovingFolder || homeViewModel.isSettingMenu ? 0.5 : 0)
                 .ignoresSafeArea(edges: .bottom)
             
-            if isEditingTitle {
-                RenamePaperTitleView(
-                    isEditingTitle: $isEditingTitle,
-                    paperInfo: homeViewModel.paperInfos.first { $0.id == selectedItemID! }!)
-            }
-            
             if createFolder || isEditingFolder {
                 FolderView(
                     createFolder: $createFolder,
@@ -208,6 +202,25 @@ struct HomeView: View {
                     title: Text("중복된 파일 이름이 있습니다."),
                     message: Text("파일 이름을 수정해주세요."),
                     dismissButton: .default(Text("Ok")))
+            }
+        }
+        .blur(radius: ((homeViewModel.viewStatus != .normal) || (homeSearchViewModel.viewStatus != .normal)) ? 5 : 0)
+        .overlay {
+            if case let .search(paperInfo) = homeViewModel.viewStatus {
+                RenamePaperTitleView(paperInfo: paperInfo) {
+                    homeViewModel.viewStatus = .normal
+                } completeAction: { text in
+                    
+                }
+                .ignoresSafeArea(edges: .top)
+            }
+            
+            if case let .search(paperInfo) = homeSearchViewModel.viewStatus {
+                RenamePaperTitleView(paperInfo: paperInfo) {
+                    homeSearchViewModel.cancelButtonTappedInEditingTitle()
+                } completeAction: { text in
+                    homeSearchViewModel.completeButtonTappedInEditingTitle(title: text)
+                }
             }
         }
     }
@@ -444,109 +457,6 @@ private struct EditMenuView: View {
     }
 }
 
-/// 논문 타이틀 수정 뷰
-struct RenamePaperTitleView: View {
-    @EnvironmentObject private var homeViewModel: HomeViewModel
-    
-    @State private var text: String = ""
-    
-    @Binding var isEditingTitle: Bool
-    
-    let paperInfo: PaperInfo
-    
-    @FocusState private var isTextFieldFocused: Bool
-    
-    var body: some View {
-        ZStack {
-            VStack {
-                HStack {
-                    Button {
-                        isEditingTitle.toggle()
-                        isTextFieldFocused = false
-                    } label: {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 18))
-                    }
-                    .foregroundStyle(.gray100)
-                    .padding(28)
-                    
-                    Spacer()
-                    
-                    Button(action: {
-                        homeViewModel.updateTitle(at: paperInfo.id, title: text)
-                        isEditingTitle = false
-                        isTextFieldFocused = false
-                    }) {
-                        RoundedRectangle(cornerRadius: 20)
-                            .stroke(.gray100, lineWidth: 1)
-                            .frame(width: 68, height: 36)
-                            .overlay {
-                                Text("완료")
-                                    .reazyFont(.button1)
-                                    .foregroundStyle(.gray100)
-                            }
-                    }
-                    .padding(28)
-                }
-                
-                Spacer()
-            }
-            HStack(spacing: 54) {
-                Image(uiImage: .init(data: paperInfo.thumbnail)!)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 196)
-                
-                VStack(spacing: 16) {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 12)
-                            .foregroundStyle(.gray100)
-                            .frame(width: 400, height: 52)
-                        
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(lineWidth: 1)
-                            .foregroundStyle(.gray400)
-                            .frame(width: 400, height: 52)
-                    }
-                    .frame(width: 400, height: 52)
-                    .overlay(alignment: .center) {
-                        TextField("제목을 입력해주세요.", text: $text, axis: .horizontal)
-                            .lineLimit(1)
-                            .padding(.horizontal, 16)
-                            .font(.custom(ReazyFontType.pretendardMediumFont, size: 16))
-                            .foregroundStyle(.gray800)
-                    }
-                    .overlay(alignment: .trailing) {
-                        if !self.text.isEmpty {
-                            Image(systemName: "xmark.circle.fill")
-                                .font(.system(size: 18))
-                                .foregroundStyle(.gray600)
-                                .background(.gray100)
-                                .padding(.trailing, 10)
-                                .onTapGesture {
-                                    text = ""
-                                }
-                        }
-                    }
-                    .focused($isTextFieldFocused)
-                    
-                    Text("논문 제목을 입력해 주세요")
-                        .reazyFont(.button1)
-                        .foregroundStyle(.comment)
-                }
-            }
-        }
-        .onAppear {
-            if let title = homeViewModel.changedTitle {
-                self.text = title
-            } else {
-                self.text = paperInfo.title
-            }
-            
-            isTextFieldFocused = true
-        }
-    }
-}
 
 /// 폴더 생성 뷰
 struct FolderView: View {

--- a/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -81,6 +81,7 @@ class HomeViewModel: ObservableObject {
     @Published public var errorStatus: PDFUploadError = .failedToAccessingSecurityScope
     
     @Published public var isSettingMenu: Bool = false
+    @Published public var viewStatus: SearchViewStatus = .normal
     public var isInHomeView: Bool = true
     
     private let homeViewUseCase: HomeViewUseCase
@@ -112,6 +113,11 @@ class HomeViewModel: ObservableObject {
     
     deinit {
         self.cancellables.forEach { $0.cancel() }
+    }
+    
+    enum SearchViewStatus: Hashable {
+        case normal
+        case search(PaperInfo)
     }
 }
 
@@ -239,9 +245,7 @@ extension HomeViewModel {
             
             switch result {
             case .success:
-                if isInHomeView {
-                    paperInfos[index].title = title
-                }
+                paperInfos[index].title = title
                 
                 PDFSharedData.shared.paperInfo?.title = title
                 

--- a/Presentation/MainPDF/MainPDFView.swift
+++ b/Presentation/MainPDF/MainPDFView.swift
@@ -423,13 +423,6 @@ struct MainPDFView: View {
                         .zIndex(1)
                 }
                 
-                if isEditingTitle {
-                    RenamePaperTitleView(
-                        isEditingTitle: $isEditingTitle,
-                        paperInfo: PDFSharedData.shared.paperInfo!
-                    )
-                }
-                
                 if isMovingFolder {
                     if let paperInfo = PDFSharedData.shared.paperInfo {
                         let itemsToMove: FileSystemItem = FileSystemItem.paper(paperInfo)
@@ -494,9 +487,19 @@ struct MainPDFView: View {
                 }
             }
         }
+        .blur(radius: homeViewModel.viewStatus != .normal ? 5 : 0)
         .overlay {
             if self.focusFigureViewModel.figureStatus == .loading {
                 FigureLoadingView()
+            }
+            
+            if case let .search(paper) = homeViewModel.viewStatus {
+                RenamePaperTitleView(paperInfo: paper) {
+                    homeViewModel.viewStatus = .normal
+                } completeAction: { text in
+                    homeViewModel.updateTitle(at: paper.id, title: text)
+                    homeViewModel.viewStatus = .normal
+                }
             }
         }
     }

--- a/Presentation/MainPDF/PDFInfoMenu.swift
+++ b/Presentation/MainPDF/PDFInfoMenu.swift
@@ -96,7 +96,7 @@ struct PDFInfoMenu: View {
             VStack(spacing: 10) {
                 Button(action: {
                     self.mainPDFViewModel.isMenuSelected = false
-                    self.isEditingTitle = true
+                    homeViewModel.viewStatus = .search(pdfSharedData.paperInfo!)
                 }, label: {
                     HStack{
                         Text("제목 수정")
@@ -199,15 +199,6 @@ struct PDFInfoMenu: View {
                     x: 0,
                     y: 0)
         )
-        .onAppear {
-            if let paperInfo = PDFSharedData.shared.paperInfo {
-                self.isStarSelected = paperInfo.isFavorite
-                
-                if title == nil {
-                    self.title = paperInfo.title
-                }
-            }
-        }
         .onDisappear {
             homeViewModel.changedTitle = nil
         }

--- a/Presentation/OriginalPaper/OriginalViewController.swift
+++ b/Presentation/OriginalPaper/OriginalViewController.swift
@@ -265,7 +265,12 @@ extension OriginalViewController {
                             self.commentViewModel.isMenuTapped = false
                             
                             if self.viewModel.isCommentTapped, let buttonID = annotation.contents {
-                                self.viewModel.selectedComments = self.commentViewModel.comments.filter { $0.buttonId.uuidString == buttonID }
+                                let splittedContents = buttonID.split(separator: "|")
+                                let selectedComments = self.commentViewModel.comments.filter {
+                                    $0.buttonId.uuidString == (splittedContents.count > 1 ? splittedContents.last! : splittedContents[0])
+                                }
+                                
+                                self.viewModel.selectedComments = selectedComments
                                 self.commentViewModel.setCommentPosition(selectedComments: self.viewModel.selectedComments, pdfView: self.mainPDFView)
                             }
                             self.viewModel.setHighlight(selectedComments: self.viewModel.selectedComments, isTapped: self.viewModel.isCommentTapped)

--- a/Reazy.xcodeproj/project.pbxproj
+++ b/Reazy.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		2CC431542CE9CA3E00E51DB0 /* HomeViewUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC431532CE9CA3E00E51DB0 /* HomeViewUseCase.swift */; };
 		2CC431572CE9CED500E51DB0 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC431562CE9CED500E51DB0 /* HomeViewModel.swift */; };
 		2CD48F562CFC3F8D004A5949 /* OrientationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD48F552CFC3F8D004A5949 /* OrientationManager.swift */; };
+		2CE743922D65BBF2006A81BE /* DynamicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE743912D65BBE6006A81BE /* DynamicCell.swift */; };
 		2CEBB6292D5A36BA00EC04D2 /* Date + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CEBB6282D5A36BA00EC04D2 /* Date + Extension.swift */; };
 		67DA8C852CF7374300B232E2 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 67DA8C842CF7374300B232E2 /* FirebaseAnalytics */; };
 		67E8AB792CF0C33000FACBAB /* TemporaryAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E8AB782CF0C31300FACBAB /* TemporaryAlertView.swift */; };
@@ -217,6 +218,7 @@
 		2CC431532CE9CA3E00E51DB0 /* HomeViewUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewUseCase.swift; sourceTree = "<group>"; };
 		2CC431562CE9CED500E51DB0 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		2CD48F552CFC3F8D004A5949 /* OrientationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationManager.swift; sourceTree = "<group>"; };
+		2CE743912D65BBE6006A81BE /* DynamicCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicCell.swift; sourceTree = "<group>"; };
 		2CEBB6282D5A36BA00EC04D2 /* Date + Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date + Extension.swift"; sourceTree = "<group>"; };
 		67E8AB782CF0C31300FACBAB /* TemporaryAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporaryAlertView.swift; sourceTree = "<group>"; };
 		6E130D542D5860C40089A493 /* TagDataRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagDataRepository.swift; sourceTree = "<group>"; };
@@ -454,6 +456,7 @@
 			children = (
 				2C1473DC2CE73D4300B35D92 /* Repositories */,
 				2C5C24192CE9E1A500C37A1B /* PDFSharedData.swift */,
+				2CE743912D65BBE6006A81BE /* DynamicCell.swift */,
 			);
 			path = Interfaces;
 			sourceTree = "<group>";
@@ -1035,6 +1038,7 @@
 				2C5C24172CE9DB9E00C37A1B /* PDFUploadError.swift in Sources */,
 				2C1474422CE900A700B35D92 /* UIBezierPath+.swift in Sources */,
 				2C1473F42CE8828800B35D92 /* PageListUseCase.swift in Sources */,
+				2CE743922D65BBF2006A81BE /* DynamicCell.swift in Sources */,
 				2C14741A2CE8F52200B35D92 /* TranslationUseCase.swift in Sources */,
 				2C2C358A2CEB24D800552185 /* MenuView.swift in Sources */,
 				2C14738E2CE73B6F00B35D92 /* PersistantContainer.swift in Sources */,


### PR DESCRIPTION
## 변경 사항
- [x] 홈 검색 뷰와 PDFCell에 데이터 연결
- [x] Cell Actions 구현
  * 즐겨찾기
  * 삭제
  * 복제
  * 이름 변경


## 스크린샷 or 영상 링크

### 태그 구현

<img width="813" alt="스크린샷 2025-02-20 오후 8 41 12" src="https://github.com/user-attachments/assets/935b2216-34a1-45ce-9b01-0527ba009f4d" />


### 이름 수정

https://github.com/user-attachments/assets/35c38fb8-53d1-4171-97b9-594c29ff1c62



### 복제 기능

https://github.com/user-attachments/assets/e3768fec-60a9-4578-8284-d4418e51d153


### 삭제 기능

https://github.com/user-attachments/assets/154d72c4-7a5c-4e0c-b1bf-e0d6e8e0618f




## 팀원에게 전달할 사항(Optional)
* 이동/ 태그 관리 action은 다른 분 작업에 포함되어 있어 직접 연결해주시면 될 듯 합니다!!
* 논문 이름 변경 View가 재사용성이 있어 보여 여러군데에서 사용할 수 있게 컴포넌트화 했습니다.
* 검색 뷰에서 Tag를 눌렀을 때는 어떤 action이 실행되어야 할 지 몰라서 일단 비워놓았습니다. 확정되는대로 수정해 놓겠습니다.

close #473 

