### PR TITLE
[Fix] 파일 복제 버그 수정

### DIFF
--- a/Data/CoreData/Repositories/PaperDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/PaperDataRepositoryImpl.swift
@@ -85,7 +85,9 @@ final class PaperDataRepositoryImpl: PaperDataRepository {
                         let newUrl = url.deletingLastPathComponent().appending(path: info.title + ".pdf")
                         
                         if let _ = try? FileManager.default.moveItem(at: url, to: newUrl) {
-                            dataToEdit.url = try! newUrl.bookmarkData(options: .minimalBookmark)
+                            let newBookmarkData = try! newUrl.bookmarkData(options: .minimalBookmark)
+                            dataToEdit.url = newBookmarkData
+                            PDFSharedData.shared.paperInfo?.url = newBookmarkData
                         } else {
                             return .failure(PDFUploadError.fileNameDuplication)
                         }

--- a/Presentation/Helper/Errors/HomeViewError.swift
+++ b/Presentation/Helper/Errors/HomeViewError.swift
@@ -1,0 +1,14 @@
+//
+//  HomeViewError.swift
+//  Reazy
+//
+//  Created by 문인범 on 3/9/25.
+//
+
+import Foundation
+
+
+enum HomeViewError: Error {
+    case cannotCreateBookmark
+    case bookmarkNotFound
+}

--- a/Presentation/Home/Paper/PaperListView.swift
+++ b/Presentation/Home/Paper/PaperListView.swift
@@ -37,6 +37,8 @@ struct PaperListView: View {
     @State private var isMenuOpen: Bool = false
     @State private var buttonPosition: CGRect = .zero
     
+    @State private var isErrorAlertPresented: Bool = false
+    
     var body: some View {
         GeometryReader { geometry in
             ZStack {
@@ -164,7 +166,8 @@ struct PaperListView: View {
                                                         
                                                         if selectedItemID == paperInfo.id {
                                                             self.isNavigationPushed = true
-                                                            navigateToPaper()
+                                                            // TODO: 에러 처리 필요
+                                                            try? navigateToPaper()
                                                             homeViewModel.updateLastModifiedDate(at: paperInfo.id, lastModifiedDate: Date())
                                                         } else {
                                                             selectedItemID = paperInfo.id
@@ -369,7 +372,7 @@ extension PaperListView {
 extension PaperListView {
     
     // TODO: URL 분리 필요
-    private func navigateToPaper() {
+    private func navigateToPaper() throws {
         guard let selectedPaperID = selectedItemID,
               let selectedPaper = homeViewModel.paperInfos.first(where: { $0.id == selectedPaperID }) else {
             return
@@ -380,14 +383,14 @@ extension PaperListView {
         
         guard let url = try? URL.init(resolvingBookmarkData: data, bookmarkDataIsStale: &isStale) else {
             print("bookmarkdata to url failed")
-            return
+            throw HomeViewError.bookmarkNotFound
         }
         
         if isStale {
             print("Bookmark(\(url.lastPathComponent)) is stale")
             guard let newURL = try? url.bookmarkData(options: .minimalBookmark) else {
                 print("Unable to create bookmark")
-                return
+                throw HomeViewError.cannotCreateBookmark
             }
             
             let idx = homeViewModel.paperInfos.firstIndex { $0.id == selectedPaperID }!

--- a/Presentation/MainPDF/MainPDFView.swift
+++ b/Presentation/MainPDF/MainPDFView.swift
@@ -464,7 +464,8 @@ struct MainPDFView: View {
                 self.homeViewModel.isInHomeView = true
                 self.searchViewModel.removeAllAnnotations()
                 PDFSharedData.shared.updatePaperInfo()
-                mainPDFViewModel.savePDF(pdfView: mainPDFViewModel.pdfDrawer.pdfView)
+                // TODO: 에러 처리 필요
+                try? mainPDFViewModel.savePDF(pdfView: mainPDFViewModel.pdfDrawer.pdfView)
                 self.focusFigureViewModel.stopTask()
                 self.focusFigureViewModel.cancellables.removeAll()
                 

--- a/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
+++ b/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
@@ -126,12 +126,12 @@ final class MainPDFViewModel: ObservableObject {
 
 // MARK: - 초기 세팅 메소드
 extension MainPDFViewModel {
-    public func savePDF(pdfView: PDFView) {
-        print("savePDF")
+    public func savePDF(pdfView: PDFView) throws {
+        var a = false
         guard let document = pdfView.document else { return }
-        guard let pdfURL = document.documentURL else {
+        guard let pdfURL = PDFSharedData.shared.paperInfo?.url, let url = try? URL(resolvingBookmarkData: pdfURL, bookmarkDataIsStale: &a) else {
             print("PDF URL을 찾을 수 없습니다.")
-            return
+            throw HomeViewError.cannotCreateBookmark
         }
         
         for pageIndex in 0..<document.pageCount {
@@ -148,7 +148,7 @@ extension MainPDFViewModel {
         // PDF 파일을 지정한 URL에 덮어쓰기 저장
         do {
             let pdfData = document.dataRepresentation()
-            try pdfData?.write(to: pdfURL)
+            try pdfData?.write(to: url)
             print("PDF 저장이 완료되었습니다.")
         } catch {
             print("PDF 저장 중 오류 발생: \(error.localizedDescription)")

--- a/Reazy.xcodeproj/project.pbxproj
+++ b/Reazy.xcodeproj/project.pbxproj
@@ -358,6 +358,11 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
+		2CC7D9032D7D92B700D882D6 /* Errors */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Errors;
+			sourceTree = "<group>";
+		};
 		2CEBB8C12D5A407E00EC04D2 /* HomeSearch */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = HomeSearch;
@@ -624,6 +629,7 @@
 		2C1474132CE8F2CC00B35D92 /* Helper */ = {
 			isa = PBXGroup;
 			children = (
+				2CC7D9032D7D92B700D882D6 /* Errors */,
 				2C14731D2CE73B6F00B35D92 /* NotificationCenter + Extension.swift */,
 				2CD48F552CFC3F8D004A5949 /* OrientationManager.swift */,
 				2C1474142CE8F2D500B35D92 /* Navigation */,
@@ -911,6 +917,7 @@
 				2C14745F2CE900FE00B35D92 /* DTO */,
 				2C3A2D092D4CF76800ED121D /* Collection */,
 				2C5C24142CE9DB6A00C37A1B /* Preview Content */,
+				2CC7D9032D7D92B700D882D6 /* Errors */,
 				2CEBB8C12D5A407E00EC04D2 /* HomeSearch */,
 				6ED57AD02CF6F33C00358561 /* Figure */,
 				6ED57AD12CF6F34C00358561 /* Collection */,


### PR DESCRIPTION
close #483 

## 변경 사항
- [ ] 파일 이름 변경시 파일이 복제되는 현상 수정

## 팀원에게 전달할 사항(Optional)
* 논문이 열리지 않는 버그를 찾던 중 발견했습니다.
* 논문 뷰 안에서 파일 이름을 수정하고 저장을 하면 이름이 수정된 파일 + 기존 이름의 파일 이렇게 두개가 생성이 되었습니다.
  * ex) 논문1.pdf -> 논문3.pdf로 이름 수정 후 저장 -> 논문3.pdf으로 파일 이름 변경 and 논문1.pdf 새로 생성
* 해당 문제가 일어나는 이유는 이름을 변경하는 메소드는 정상적으로 실행이 되지만 마지막에 저장을 하는 부분에서 변경된 사항을 반영받지 못해 기존 이름으로 저장을 진행해서 새로운 파일이 생성되는 것이었습니다.
* 해당 문제가 논문이 열리지 않는 버그의 주요 원인인지는 파악을 하지 못하겠으나 어느정도 영향이 있다고 파악됩니다!
* 혹시나 논문 열리지 않는 버그의 트리거를 알게되면 공유 부탁드립니다! 
* 저희 프로젝트가 오류 처리가 많이 미흡하여 사용자가 불편함을 많이 느낀다고 생각합니다!(ex 오류 발생시 단순 print, 사용자가 알지 못함) 그래서 나중에 오류처리를 한번 잡아야 할 듯 합니다
