### PR TITLE
[Fix] 하이라이트 지우기 오류 해결

### DIFF
--- a/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
+++ b/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
@@ -214,12 +214,9 @@ extension MainPDFViewModel {
     // UIMenu에서 하이라이트 기능
     func highlightUIMenu(in pdfView: PDFView, with color: HighlightColors) {
         
-        // PDFView 안에서 스크롤 영역 파악
-        guard let currentSelection = pdfView.currentSelection else { return }
         
-        // 선택된 텍스트를 줄 단위로 나눔
-        let selections = currentSelection.selectionsByLine()
-        
+        guard let currentSelection = pdfView.currentSelection else { return }                   // PDFView 안에서 스크롤 영역 파악
+        let selections = currentSelection.selectionsByLine()                                    // 선택된 텍스트 줄 단위로 나누기
         guard let page = selections.first?.pages.first else { return }
         
         let highlightColor = color.uiColor

--- a/Presentation/OriginalPaper/Menus/Drawing/PDFDrawer.swift
+++ b/Presentation/OriginalPaper/Menus/Drawing/PDFDrawer.swift
@@ -397,10 +397,11 @@ extension PDFDrawer: DrawingGestureRecognizerDelegate {
         
         if (pdfView.document?.index(for: page)) != nil {
             for annotation in annotations {
-                // 하이라이트랑 드로잉만 지우기
-                if annotation.type == "Ink" || (annotation.type == "Highlight" && annotation.value(forAnnotationKey: .contents) == nil) {
-                    _ = annotation.bounds
-                    
+                // 드로잉 또는 하이라이트 지우기
+                if annotation.type == "Ink" ||
+                    (annotation.type == "Highlight" &&
+                     // 기존 하이라이트 (highlight.contents의 값이 없는 경우) || 새로운 하이라이트 (highlight.contents의 값이 있는 경우) 지우기
+                     (annotation.value(forAnnotationKey: .contents) == nil || annotation.contents?.hasPrefix("UH|") == true)) {
                     annotationHistory.append((action: .remove(annotation), annotation: annotation, page: page))
                     page.removeAnnotation(annotation)
                 }

--- a/Presentation/OriginalPaper/OriginalViewController.swift
+++ b/Presentation/OriginalPaper/OriginalViewController.swift
@@ -73,6 +73,7 @@ final class OriginalViewController: UIViewController {
         self.setBinding()
         self.focusFigureViewModel.fetchAnnotations()
     }
+    
     // Editmenu 관련
     override func buildMenu(with builder: UIMenuBuilder) {
         super.buildMenu(with: builder)


### PR DESCRIPTION
## 변경 사항
- [x] 하이라이트가 지워지지 않는 문제를 해결하였습니다.


## 스크린샷 or 영상 링크
 https://github.com/user-attachments/assets/4c248bb7-6f26-49c8-82e4-ea85d82bb57a


## 팀원에게 전달할 사항(Optional)
| 모아보기를 위해 highlight.contents에 String 값을 저장하는 로직을 추가했는데, 지우개 로직에 이 값이 nil 인 경우에 지운다는 조건이 있어 새로운 하이라이트가 지워지지 않는 문제가 발생하였고, 이를 해결하였습니다.

기존 지우개 로직을 지우면 highlight.contents에 값을 저장하지 않았던 기존 사용자들의 하이라이트가 지워지지 않아, 새로운 조건을 추가하였습니다.

close #490 