### PR TITLE
[Fix] PDF 공유시 하이라이트 추출

### DIFF
--- a/Presentation/MainPDF/PDFInfoMenu.swift
+++ b/Presentation/MainPDF/PDFInfoMenu.swift
@@ -215,7 +215,10 @@ struct PDFInfoMenu: View {
             
             // 각 페이지의 모든 주석을 반복하며 밑줄과 코멘트 아이콘 지우기
             for annotation in page.annotations {
-                if annotation.value(forAnnotationKey: .contents) != nil {
+                guard let contents = annotation.contents else { continue }
+                
+                // 하이라이트의 contents가 "UH|"로 시작하면 지우지 않기
+                if !contents.hasPrefix("UH|") {
                     page.removeAnnotation(annotation)
                 }
             }

--- a/Presentation/OriginalPaper/Menus/FigureList/Collection/CollectionMenu.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Collection/CollectionMenu.swift
@@ -69,7 +69,7 @@ struct CollectionMenu: View {
                             
                             Spacer()
                             
-                            Image(.share)
+                            Image(systemName: "square.and.arrow.down")
                                 .renderingMode(.template)
                                 .resizable()
                                 .scaledToFit()

--- a/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureMenu.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureMenu.swift
@@ -70,7 +70,7 @@ struct FigureMenu: View {
                             
                             Spacer()
                             
-                            Image(.share)
+                            Image(systemName: "square.and.arrow.down")
                                 .renderingMode(.template)
                                 .resizable()
                                 .scaledToFit()


### PR DESCRIPTION
## 변경 사항
- [x] Reazy에서 작성한 PDF 추출시 하이라이트가 저장되지 않는 문제 해결
- [x] 이미지 저장하기 아이콘 변경


## 스크린샷 or 영상 링크
|

<img width="1047" alt="image" src="https://github.com/user-attachments/assets/8f06fdf8-d83e-4451-a647-167769e1d87d" />


## 팀원에게 전달할 사항(Optional)
|
신규 하이라이트, 기존 하이라이트, 펜 저장되고, 코멘트는 지워서 PDF 추출 확인했습니다

close #499 
