### PR TITLE
[Fix] Figure 추출 시 무한로딩 에러 해결

### DIFF
--- a/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
@@ -142,13 +142,16 @@ extension FocusFigureViewModel {
             
             guard let url = try? URL.init(
                 resolvingBookmarkData: self.focusFigureUseCase.pdfSharedData.paperInfo!.url,
-                bookmarkDataIsStale: &isStale),
-                  url.startAccessingSecurityScopedResource() else {
+                bookmarkDataIsStale: &isStale) else {
                 return
             }
             
+            let accessed = url.startAccessingSecurityScopedResource()
+            // startAccessing이 실패해도 그냥 쓸 수 있게 guard 문에서 빼서 처리
             defer {
-                url.stopAccessingSecurityScopedResource()
+                if accessed {
+                    url.stopAccessingSecurityScopedResource()
+                }
             }
             
             Task.init {


### PR DESCRIPTION
## 변경 사항
- [ ] startAccessingSecurityScopedResource를 guard 문에서 제외 후 안전하게 처리


## 스크린샷 or 영상 링크
|


## 팀원에게 전달할 사항(Optional)
|

