### PR TITLE
[Fix] 4.0 HomeView QA 내용 반영

### DIFF
--- a/Data/CoreData/Reazy.xcdatamodeld/Reazy4.0.xcdatamodel/contents
+++ b/Data/CoreData/Reazy.xcdatamodeld/Reazy4.0.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23605" systemVersion="24E248" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24E263" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="ButtonGroupData" representedClassName="ButtonGroupData" syncable="YES">
         <attribute name="buttonPosition" optional="YES" attributeType="Binary" valueTransformerName="CGRectValueTransformer"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
@@ -55,7 +55,7 @@
     <entity name="PaperTag" representedClassName="PaperTag" syncable="YES">
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <relationship name="paperData" maxCount="1" deletionRule="No Action" destinationEntity="PaperData" inverseName="paperTags" inverseEntity="PaperData"/>
-        <relationship name="tagData" maxCount="1" deletionRule="Nullify" destinationEntity="TagData" inverseName="paperTag" inverseEntity="TagData"/>
+        <relationship name="tagData" maxCount="1" deletionRule="Nullify" destinationEntity="TagData" inverseName="paperTags" inverseEntity="TagData"/>
     </entity>
     <entity name="SelectionByLine" representedClassName="SelectionByLine" syncable="YES">
         <attribute name="bounds" optional="YES" attributeType="Binary" valueTransformerName="CGRectValueTransformer"/>
@@ -65,6 +65,6 @@
     <entity name="TagData" representedClassName="TagData" syncable="YES">
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
-        <relationship name="paperTag" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="PaperTag" inverseName="tagData" inverseEntity="PaperTag"/>
+        <relationship name="paperTags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PaperTag" inverseName="tagData" inverseEntity="PaperTag"/>
     </entity>
 </model>

--- a/Domain/Entities/PaperInfo.swift
+++ b/Domain/Entities/PaperInfo.swift
@@ -23,8 +23,6 @@ struct PaperInfo: Identifiable, Hashable, Codable, Transferable {
     var folderID: UUID?
     var tags: [Tag]
     
-    var isSelected: Bool = false
-    
     init(
         id: UUID = .init(),
         title: String,

--- a/Domain/Entities/Tag.swift
+++ b/Domain/Entities/Tag.swift
@@ -41,3 +41,16 @@ struct Tag: DynamicCell, Codable, Transferable {
         CodableRepresentation(contentType: .text)
     }
 }
+
+
+extension Tag: Hashable {
+    static func == (lhs: Tag, rhs: Tag) -> Bool {
+        if lhs.id == rhs.id, lhs.name == rhs.name { return true }
+        return false
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(name)
+    }
+}

--- a/Domain/UseCases/HomeViewUseCase.swift
+++ b/Domain/UseCases/HomeViewUseCase.swift
@@ -160,6 +160,7 @@ class DefaultHomeViewUseCase: HomeViewUseCase {
             self.paperDataRepository.savePDFInfo(samplePaperInfo)
             
             self.paperDataRepository.addTag(to: guidePaperInfo.id, with: "Reazy")
+            self.paperDataRepository.addTag(to: samplePaperInfo.id, with: "Reazy")
 
             return [guidePaperInfo, samplePaperInfo]
         } else {

--- a/Domain/UseCases/TagViewUseCase.swift
+++ b/Domain/UseCases/TagViewUseCase.swift
@@ -62,7 +62,17 @@ final class DefaultTagViewUseCase: TagViewUseCase {
         
         tags.forEach {
             if case let .success(paperInfos) = tagDataRepository.fetchPapersByTag(tagID: $0.id) {
-                paperInfos.forEach { result.insert($0) }
+                var isTagContained = true
+                paperInfos.forEach { paperInfo in
+                    for tag in tags {
+                        if !paperInfo.tags.contains(tag) {
+                            isTagContained = false
+                            break
+                        }
+                    }
+                    
+                    if isTagContained { result.insert(paperInfo) }
+                }
             }
         }
         

--- a/Presentation/Home/HomeFolderPopoverView.swift
+++ b/Presentation/Home/HomeFolderPopoverView.swift
@@ -24,13 +24,18 @@ struct HomeFolderPopoverView: View {
                     divider
                     PopoverActionView(popoverAction: .addParentFolder) {
                         homeViewModel.viewStatus = .normal
-                        homeViewModel.folderCreationPosition = .aboveCurrent
-                        homeViewModel.createFolder = true
+                        
+                        if homeViewModel.totalDepthInBranch(for: homeViewModel.selectedFolderID) < 4 {
+                            homeViewModel.folderCreationPosition = .aboveCurrent
+                            homeViewModel.createFolder = true
+                        } else {
+                            homeViewModel.showFolderDepthAlert = true
+                        }
                     }
                     divider
                     PopoverActionView(popoverAction: .addSubFolder) {
                         homeViewModel.viewStatus = .normal
-                        if homeViewModel.depth(of: homeViewModel.currentFolder) < 4 {
+                        if homeViewModel.depth(of: homeViewModel.selectedFolderID) < 4 {
                             homeViewModel.folderCreationPosition = .intoCurrent
                             homeViewModel.createFolder = true
                         } else {

--- a/Presentation/Home/HomeListView.swift
+++ b/Presentation/Home/HomeListView.swift
@@ -39,7 +39,7 @@ struct HomeListView: View {
                     Spacer()
                     
                     Button(action: {
-                        if homeViewModel.depth(of: homeViewModel.currentFolder) < 4 {
+                        if homeViewModel.depth(of: homeViewModel.currentFolder?.id) < 4 {
                             homeViewModel.folderCreationPosition = .intoCurrent
                             homeViewModel.createFolder = true
                         } else {

--- a/Presentation/Home/HomeListView.swift
+++ b/Presentation/Home/HomeListView.swift
@@ -241,9 +241,11 @@ private struct FolderListCell: View {
                 LongPressGesture(minimumDuration: 0.5)
                     .sequenced(before: DragGesture(minimumDistance: 0, coordinateSpace: .global))
                     .updating($highlight) { currentState, gestureState, transaction in
-                        self.animationFolder = folder
-                        transaction.animation = .easeIn(duration: 1)
-                        gestureState = true
+                        if case .second(true, _) = currentState {
+                            self.animationFolder = folder
+                            transaction.animation = .easeIn(duration: 1)
+                            gestureState = true
+                        }
                     }
                     .onEnded { value in
                         switch value {

--- a/Presentation/Home/HomeListView.swift
+++ b/Presentation/Home/HomeListView.swift
@@ -109,7 +109,7 @@ struct HomeListView: View {
         category: CategorySelection
     ) -> some View {
         RoundedRectangle(cornerRadius: 12)
-            .foregroundStyle(selectedCategory == category ? Color(hex: "EFEFF8") : .primary2)
+            .foregroundStyle(selectedCategory == category ? .gray300 : .primary2)
             .frame(height: 43)
             .overlay {
                 HStack(spacing: 0) {

--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct HomePDFCell: View {
     @State private var popover = false
     @State var paperInfo: PaperInfo
+    @Binding var isSelected: Bool
     
     var cellStatus: CellStatus
     let screenWidth: CGFloat
@@ -31,8 +32,8 @@ struct HomePDFCell: View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
                 if case .selection = cellStatus {
-                    SelectionCheckView(isSelected: paperInfo.isSelected) {
-                        paperInfo.isSelected.toggle()
+                    SelectionCheckView(isSelected: isSelected) {
+                        isSelected.toggle()
                         checkAction()
                     }
                     .padding(.leading, 10)
@@ -100,7 +101,7 @@ struct HomePDFCell: View {
                 .frame(height: 1)
         }
         .background {
-            if case .selection = cellStatus, paperInfo.isSelected {
+            if case .selection = cellStatus, isSelected {
                 RoundedRectangle(cornerRadius: 12)
                     .foregroundStyle(.primary2)
                     .padding(.vertical, 6)

--- a/Presentation/Home/HomeSearch/Cell/PDFTagCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/PDFTagCell.swift
@@ -30,10 +30,10 @@ struct PDFTagCell<Tag: DynamicCell>: View {
                     .reazyFont(isMultiSelectable ? .body1 : .h3)
                     .foregroundStyle(tag.isSelected ? .gray300 : .gray800)
                     .fixedSize(horizontal: true, vertical: false)
-                    .padding(.trailing, 4)
                 
                 // 삭제 버튼
                 if isEditMode {
+                    Spacer().frame(width: 4)
                     Button {
                         deleteAction()
                     } label: {

--- a/Presentation/Home/HomeSearch/HomeSearchView.swift
+++ b/Presentation/Home/HomeSearch/HomeSearchView.swift
@@ -57,7 +57,6 @@ private struct HomeSearchListView: View {
                             homeSearchViewModel.searchTarget == .tag ? .primary1 : .gray550
                         )
                         .padding(.leading, 20)
-                        .padding(.vertical, 20)
                 }
                 
                 Spacer()
@@ -99,6 +98,7 @@ private struct HomeSearchListView: View {
                                     homeSearchViewModel.setTagButtonTapped(paperInfo)
                                 }
                             }
+                            .padding(.leading, 24)
                         }
                     }
                 }
@@ -121,6 +121,7 @@ private struct HomeSearchListView: View {
                 }
             }
         }
+        .background(.gray300)
         .alert("정말 삭제하시겠습니까?", isPresented: $deleteAlertPresented) {
             Button("삭제", role: .destructive) {
                 if let paperInfo = selectedPaper {
@@ -163,6 +164,7 @@ private struct RecentlySearchedKeywordView: View {
                 }
                 Spacer()
             }
+            .background(.gray300)
         } else {
             VStack(alignment: .leading, spacing: 0) {
                 HStack {
@@ -191,6 +193,7 @@ private struct RecentlySearchedKeywordView: View {
             }
             .padding(.top, 50)
             .padding(.horizontal, 20)
+            .background(.gray300)
         }
     }
 }

--- a/Presentation/Home/HomeSearch/HomeSearchView.swift
+++ b/Presentation/Home/HomeSearch/HomeSearchView.swift
@@ -72,7 +72,7 @@ private struct HomeSearchListView: View {
                     GeometryReader { geometry in
                         VStack(spacing: 0) {
                             ForEach(homeSearchViewModel.searchList) { paperInfo in
-                                HomePDFCell(paperInfo: paperInfo, cellStatus: .search, screenWidth: isPortrait ? geometry.size.width * 0.7 :  geometry.size.width * 0.8) {
+                                HomePDFCell(paperInfo: paperInfo, isSelected: .constant(false), cellStatus: .search, screenWidth: isPortrait ? geometry.size.width * 0.7 :  geometry.size.width * 0.8) {
                                     // TODO: 네비게이션 push 시 Date 업데이트 필요
                                     homeSearchViewModel.PaperCellTapped(paperInfo)
                                     navigationCoordinator.push(.mainPDF(paperInfo: paperInfo))

--- a/Presentation/Home/HomeView.swift
+++ b/Presentation/Home/HomeView.swift
@@ -134,9 +134,6 @@ struct HomeView: View {
                 .clipShape(RoundedRectangle(cornerRadius: 20))
                 .frame(width: 740, height: 550)
                 .blur(radius: createMovingFolder ? 20 : 0)
-                .onDisappear {
-                    homeViewModel.selectedItems.removeAll()
-                }
             }
             
             Color.black
@@ -483,6 +480,7 @@ private struct EditMenuView: View {
                     .frame(width: 20, height: 20)
                     .foregroundStyle(homeViewModel.selectedItems.isEmpty ? .gray550 : .gray100)
             })
+            .disabled(homeViewModel.selectedItems.isEmpty)
             .padding(.trailing, 28)
             
             Button(action: {

--- a/Presentation/Home/HomeView.swift
+++ b/Presentation/Home/HomeView.swift
@@ -99,7 +99,12 @@ struct HomeView: View {
             
             
             Color.black
-                .opacity(isEditingTitle || homeViewModel.createFolder || homeViewModel.isEditingFolder || homeViewModel.isMovingFolder || homeViewModel.isSettingMenu || tagViewModel.createTag || tagViewModel.isTagDuplicate || tagViewModel.showDeleteAlert || isDuplicatedTitleAlertPresented ? 0.5 : 0)
+                .opacity(
+                    isEditingTitle || homeViewModel.createFolder || homeViewModel.isEditingFolder
+                    || homeViewModel.isMovingFolder || homeViewModel.isSettingMenu || tagViewModel.createTag
+                    || tagViewModel.isTagDuplicate || tagViewModel.showDeleteAlert || isDuplicatedTitleAlertPresented
+                    || homeViewModel.showDeleteAlert
+                    ? 0.5 : 0)
                 .ignoresSafeArea(edges: .bottom)
             
             Color.black
@@ -246,7 +251,8 @@ struct HomeView: View {
             
             if homeViewModel.showDeleteAlert {
                 CustomAlert(
-                    mainText: "삭제하시겠습니까?\n삭제된 항목은 복구할 수 없습니다.",
+                    mainText: "폴더를 삭제하시겠습니까?",
+                    message: "폴더 안에 포함된 논문도 함께 삭제됩니다.",
                     width: 364, height: 163,
                     cancelAction: { homeViewModel.showDeleteAlert = false },
                     confirmAction: {

--- a/Presentation/Home/MoveFolderView.swift
+++ b/Presentation/Home/MoveFolderView.swift
@@ -10,12 +10,10 @@ import SwiftUI
 struct MoveFolderView: View {
     @EnvironmentObject private var homeViewModel: HomeViewModel
     @State private var expandedFolders: Set<UUID> = []
-    @State private var isTopLevelExpanded: Bool = true
     
     @Binding var createMovingFolder: Bool
-    
-    let items: [PaperInfo] // 이동하고자 하는 Item 배열
-    @Binding var selectedID: UUID? // Item의 이동 목적지 ID
+    let items: [PaperInfo]
+    @Binding var selectedID: UUID?
     
     var body: some View {
         VStack(spacing: 0) {
@@ -44,10 +42,9 @@ struct MoveFolderView: View {
                     
                     Button(action: {
                         items.forEach { item in
-                            if selectedID == topLevelFolder.id { selectedID = nil }
                             homeViewModel.updatePaperLocation(at: item.id, folderID: selectedID)
                         }
-                        homeViewModel.isMovingFolder.toggle()
+                        homeViewModel.isMovingFolder = false
                     }) {
                         Text("이동")
                             .reazyFont(.text1)
@@ -75,17 +72,17 @@ struct MoveFolderView: View {
             
             ScrollView {
                 VStack(spacing: 0) {
-                    FolderCell(
-                        folder: topLevelFolder,
-                        level: 0,
-                        expandedFolders: $expandedFolders,
-                        isTopLevel: true,  // <전체> 폴더
-                        childFolders: childFolders(of:),
-                        toggleExpansion: toggleExpansion,
-                        hasChildren: hasChildren,
-                        isTopLevelExpanded: $isTopLevelExpanded,
-                        selectedID: $selectedID
-                    )
+                    ForEach(rootFolders, id: \.id) { folder in
+                        FolderCell(
+                            folder: folder,
+                            level: 0,
+                            expandedFolders: $expandedFolders,
+                            childFolders: childFolders(of:),
+                            toggleExpansion: toggleExpansion,
+                            hasChildren: hasChildren,
+                            selectedID: $selectedID
+                        )
+                    }
                 }
             }
         }
@@ -107,28 +104,16 @@ struct MoveFolderView: View {
         .onChange(of: homeViewModel.newFolderParentID) { _ , parentID in
             if let parentID = parentID {
                 expandedFolders.insert(parentID)
-            } else {
-                isTopLevelExpanded = true
             }
         }
     }
     
-    // 존재하지 않는 <전체> 임의 폴더 생성
-    private var topLevelFolder: Folder {
-        Folder(
-            id: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!,
-            title: "전체",
-            color: ".primary1",
-            parentFolderID: nil
-        )
+    private var rootFolders: [Folder] {
+        homeViewModel.folders.filter { $0.parentFolderID == nil }
     }
     
     private func childFolders(of folderID: UUID?) -> [Folder] {
-        if folderID == topLevelFolder.id {
-            return homeViewModel.folders.filter { $0.parentFolderID == nil }
-        } else {
-            return homeViewModel.folders.filter { $0.parentFolderID == folderID }
-        }
+        homeViewModel.folders.filter { $0.parentFolderID == folderID }
     }
     
     private func hasChildren(folder: Folder) -> Bool {
@@ -155,12 +140,9 @@ struct FolderCell: View {
     let folder: Folder
     let level: Int
     @Binding var expandedFolders: Set<UUID>
-    let isTopLevel: Bool
     let childFolders: (UUID) -> [Folder]
     let toggleExpansion: (Folder) -> Void
     let hasChildren: (Folder) -> Bool
-    @Binding var isTopLevelExpanded: Bool
-    
     @Binding var selectedID: UUID?
     
     var body: some View {
@@ -168,7 +150,7 @@ struct FolderCell: View {
             HStack(spacing: 0) {
                 RoundedRectangle(cornerRadius: 7)
                     .frame(width: 29, height: 29)
-                    .foregroundStyle(level == 0 ? .primary1 : FolderColors.color(for: folder.color))
+                    .foregroundStyle(FolderColors.color(for: folder.color))
                     .overlay(
                         Image(.folder)
                             .resizable()
@@ -187,18 +169,7 @@ struct FolderCell: View {
                         
                         Spacer()
                         
-                        if isTopLevel {
-                            Button(action: {
-                                withAnimation {
-                                    self.isTopLevelExpanded.toggle()
-                                }
-                            }) {
-                                Image(systemName: isTopLevelExpanded ? "chevron.down" : "chevron.right")
-                                    .font(.system(size: 12))
-                                    .foregroundStyle(.gray600)
-                                    .padding(.trailing, 20)
-                            }
-                        } else if hasChildren(folder) {
+                        if hasChildren(folder) {
                             Button(action: {
                                 withAnimation {
                                     toggleExpansion(folder)
@@ -225,17 +196,15 @@ struct FolderCell: View {
                 onTap()
             }
             
-            if (isTopLevel && isTopLevelExpanded) || expandedFolders.contains(folder.id) {
+            if expandedFolders.contains(folder.id) {
                 ForEach(childFolders(folder.id), id: \.id) { subFolder in
                     FolderCell(
                         folder: subFolder,
                         level: level + 1,
                         expandedFolders: $expandedFolders,
-                        isTopLevel: false,
                         childFolders: childFolders,
                         toggleExpansion: toggleExpansion,
                         hasChildren: hasChildren,
-                        isTopLevelExpanded: $isTopLevelExpanded,
                         selectedID: $selectedID
                     )
                     .transition(.move(edge: .top).combined(with: .opacity))

--- a/Presentation/Home/PaperListView.swift
+++ b/Presentation/Home/PaperListView.swift
@@ -97,6 +97,16 @@ struct PaperListView: View {
                                         ForEach(homeViewModel.filteredLists, id: \.self) { paperInfo in
                                             HomePDFCell(
                                                 paperInfo: paperInfo,
+                                                isSelected: Binding(
+                                                    get: { homeViewModel.selectedItems.contains(paperInfo.id) },
+                                                    set: { newValue in
+                                                        if newValue {
+                                                            homeViewModel.selectedItems.insert(paperInfo.id)
+                                                        } else {
+                                                            homeViewModel.selectedItems.remove(paperInfo.id)
+                                                        }
+                                                    }
+                                                ),
                                                 cellStatus: homeViewModel.selectedMenu == .edit ? .selection : .normal,
                                                 screenWidth: isPortrait ? geo.size.width * 0.6 :  geo.size.width * 0.73,
                                                 onTapGesture: {

--- a/Presentation/Home/TagSearch/TagView.swift
+++ b/Presentation/Home/TagSearch/TagView.swift
@@ -284,6 +284,7 @@ private struct FilteredPaperListView: View {
                     ForEach(tagViewModel.tagFilteredPapers, id: \.self) { paperInfo in
                         HomePDFCell(
                             paperInfo: paperInfo,
+                            isSelected: .constant(false),
                             cellStatus: homeViewModel.selectedMenu == .edit ? .selection : .normal,
                             screenWidth: isPortrait ? geometry.size.width * 0.6 :  geometry.size.width * 0.73,
                             onTapGesture: {

--- a/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -264,6 +264,7 @@ extension HomeViewModel {
         if let index = paperInfos.firstIndex(where: { $0.id == id }) {
             paperInfos[index].folderID = folderID
             self.homeViewUseCase.editPDF(paperInfos[index])
+            selectedItems.removeAll()
         }
     }
     

--- a/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -376,8 +376,11 @@ extension HomeViewModel {
 }
 
 extension HomeViewModel {
-    func depth(of folder: Folder?) -> Int {
-        guard let folder = folder else { return 0 }
+    func depth(of folderID: UUID?) -> Int {
+        guard let folderID = folderID,
+              let folder = folders.first(where: { $0.id == folderID }) else {
+            return 0
+        }
         
         var currentFolder = folder
         var depth = 1
@@ -391,6 +394,39 @@ extension HomeViewModel {
         return depth
     }
     
+    func depthAbove(folderID: UUID?) -> Int {
+        guard let folderID = folderID,
+              let folder = folders.first(where: { $0.id == folderID }) else { return 0 }
+
+        var current = folder
+        var depth = 0
+
+        while let parentID = current.parentFolderID,
+              let parent = folders.first(where: { $0.id == parentID }) {
+            current = parent
+            depth += 1
+        }
+
+        return depth
+    }
+
+    func depthBelow(folderID: UUID?) -> Int {
+        guard let folderID = folderID else { return 0 }
+
+        let children = folders.filter { $0.parentFolderID == folderID }
+
+        if children.isEmpty {
+            return 0
+        }
+
+        let childDepths = children.map { depthBelow(folderID: $0.id) }
+        return 1 + (childDepths.max() ?? 0)
+    }
+
+    func totalDepthInBranch(for folderID: UUID?) -> Int {
+        return depthAbove(folderID: folderID) + 1 + depthBelow(folderID: folderID)
+    }
+
     private func selectedFolder() -> Folder? {
         guard let selectedID = selectedFolderID else { return nil }
         return folders.first(where: { $0.id == selectedID })


### PR DESCRIPTION
## 변경 사항
### 1. 다중 선택에서 폴더 이동 취소 시 상단 버튼이 안 눌리는 문제 해결
- 다중 선택 시, 폴더 이동을 하려다가 취소할 경우 버튼이 눌리지 않는 문제가 발생했습니다. 이동 버튼과 삭제 버튼이 disabled 되는 기준은, 뷰모델이 가지고 있는 `selectedItems` 배열이 비어있는 경우였기 때문에 해당 배열을 비우는 로직이 있다고 판단되어 확인해 본 결과, `MoveFolderView`가 사라질 때 해당 배열을 비우는 코드를 작성해 두었기에 시스템이 인식하기에 배열이 비어있다 판단된 것입니다 🥹

``` Swift
.onDisappear {
    homeViewModel.selectedItems.removeAll()
}
```

위의 코드를 삭제하여 문제를 해결하였습니다!

### 2. 상하위 폴더 생성 개수 제한
- 원인은 간단합니다. 제가 `HomeListView`에 있는 폴더 추가 버튼에만 4개 제한을 제대로 걸어뒀기 때문이죠 (^^) Popover의 경우 `currentFolder`가 기준이 아닌 `selectedFolderID`가 기준이기에, 해당 값을 바탕으로 폴더 제한을 걸도록 수정하였습니다.
- 또한 상위 폴더를 생성할 때, 선택한 폴더의 상하위 depth를 모두 파악한 후, 상위 폴더를 생성했을 때 최하위 폴더의 depth가 4개를 넘어가지 않도록 조정하였습니다.

``` Swift
func totalDepthInBranch(for folderID: UUID?) -> Int {
    return depthAbove(folderID: folderID) + 1 + depthBelow(folderID: folderID)
}
```

여기서 `depthAbove`는 선택한 폴더 기준 상위 폴더의 개수, 1은 선택한 폴더, `depthBelow`는 선택한 폴더 기준 하위 폴더의 개수로 구성되어 있습니다!

### 3. 스크롤 이슈 해결
- 스크롤 이슈는 별거 없었습니다... 조건을 달지 않고 그냥 터치만 하면 animation이 먹도록 작성되어 있어서 그랬어요! 해당 코드에 조건문을 추가함으로써 스크롤 이슈를 해결하였습니당.

``` Swift
.updating($highlight) { currentState, gestureState, transaction in
    if case .second(true, _) = currentState {
        self.animationFolder = folder
        transaction.animation = .easeIn(duration: 1)
        gestureState = true
    }
}
```

### 4. 상단바가 아래로 늘어나는 이슈 해결
- 검색 뷰에 `background`가 지정되어 있지 않아 발생하는 문제로, background 지정을 해 줌으로써 해당 문제를 해결하였습니다.
- _겁나 어려웟내요 ^^ 백그라운드 문제인 줄 모르고 패딩 다 까 보고 색을 다 입혀 봤습니당._

![simulator_screenshot_38617416-7DB5-4A07-9408-434128D9BBB6](https://github.com/user-attachments/assets/450447f6-2c72-4669-a6e2-8eb3c22b3356)


### 5. 폴더 이동 뷰 전체 탭 삭제
- 기존에 임의로 만들어 두었던 전체 탭을 삭제하고 현재 존재하는 폴더만 존재할 수 있도록 수정하였습니다.

![simulator_screenshot_847A9E16-1EDB-4640-8B00-799E24F3D0E8](https://github.com/user-attachments/assets/30f833b7-ee0d-4216-b3c3-9f63057d3bd3)

### 6. 동일한 태그를 다른 페이퍼에 추가할 때 생기는 문제 해결
자 오랜 시간 여러분을 괴롭혀 온 태그 문제, 이에 관해 가장 먼저

<image src="https://github.com/user-attachments/assets/f41146cc-bba5-4075-9cd9-50d450b8a331" width=300/>

죄송하다는 말씀을 드립니다.
저도 뭔가 신내림을 받아서 띠용! 하다시피 발견한 건데, 그동안 생겼던 모든 오류를 생각해 보니 태그를 최초 1회 생성할 때에만 멀쩡하게 돌아가고, 동일한 태그를 가진 다른 Paper가 등장하는 순간 튕기게 되는 겁니다 *^^*
그렇다면 높은 확률로 하나의 Tag가 두 개의 Paper를 못 받는다는 이야기인데... 그렇담 사실 코드 문제가 아니고 CoreData 문제겠죠......

<image src="https://github.com/user-attachments/assets/436e0bd0-e9eb-47fc-9ae4-16fa3198756e" width=500/>

원인은 이겁니다!
`PaperTag`는 별도의 엔티티가 아닌 말 그대로 `Paper`과 `Tag`를 이어주는 관계형 엔티티입니다. 따라, Paper과 Tag의 관계가 다대다로 엮여있을 수 있는 환경에서 `Paper`과 `PaperTag`, `Tag`와 `PaperTag`는 모두 `To-Many` 다대다 관계형으로 엮여야 합니다.
근데 제가 CoreData를 만들 당시, 이 부분을 고려하지 못하고, 하나의 태그는 여러 페이퍼를 가질 수 있지만, 하나의 페이퍼가 여러 동일한 태그를 가질 수는 없다 (= 태그는 고유해야 한다)라는 생각으로 `Tag` 엔티티와 `PaperTag`를 `To-One`으로 갈겨뒀던 겁니다...

#### 이게 문제였어요!!!!!!

요걸 `To-Many`로 고치자마자 그 야밤 회의 전에 무니와 함께 머리 맞대고 `Reazy` 태그 왜 두 개 안 들어가냐? 논의했던 문제가 바로 해결됐습니다 ^^ 넵. **아마 이거 이후로 태그 생성 관련 문제는 다 해결되지 싶네요! 그래도 확인 부탁드립니다 🥹👍**

### 7. Tag Cell 코드 살짝 수정
``` Swift
Text(tag.name)
    .reazyFont(isMultiSelectable ? .body1 : .h3)
    .foregroundStyle(tag.isSelected ? .gray300 : .gray800)
    .fixedSize(horizontal: true, vertical: false)
                
    // 삭제 버튼
    if isEditMode {
        Spacer().frame(width: 4) // 이 코드 위치를 옮겼습니다!
        Button {
            deleteAction()
        } label: {
            Image(systemName: "x.circle.fill")
                .foregroundStyle(.gray700)
                .font(.system(size: 12))
        }
}
```

원래 태그 텍스트와 X 버튼 사이 공간을 Text의 padding으로 주었었는데, 그러다 보니 태그가 생성됐을 때 묘하게 뒷자리가 남는 느낌이 들어 삭제 한정으로 보이도록 frame 적용한 Spacer를 위치시켰습니다! 예뻐졌어용.

## 팀원에게 전달할 사항(Optional)

close #511 
