### PR TITLE
[Fix] V4.0 Tag 관련 QA 반영

### DIFF
--- a/DesignSystem/Views/DynamicCellLayout.swift
+++ b/DesignSystem/Views/DynamicCellLayout.swift
@@ -15,7 +15,7 @@ struct DynamicCellLayout<Data: RandomAccessCollection>: View where Data.Element:
     let screenWidth: CGFloat
     
     let isMultiSelectable: Bool     // 여러 셀 선택 가능
-    let isEditMode: Bool           // x마크
+    let isEditMode: Bool            // x 마크
     
     let selectAction: (String) -> Void
     let deleteAction: (UUID) -> Void
@@ -48,6 +48,7 @@ struct DynamicCellLayout<Data: RandomAccessCollection>: View where Data.Element:
             currentWidth += itemWidth
             currentArrays.append(item)
         }
+        
         return VStack(alignment: .leading) {
             ForEach(resultRows, id: \.self) { row in
                 HStack {
@@ -55,8 +56,8 @@ struct DynamicCellLayout<Data: RandomAccessCollection>: View where Data.Element:
                         PDFTagCell(isMultiSelectable: isMultiSelectable,
                                    isEditMode: isEditMode,
                                    tag: tag,
-                                   selectAction: {selectAction(tag.name)},
-                                   deleteAction: {deleteAction(tag.id)}
+                                   selectAction: { selectAction(tag.name) },
+                                   deleteAction: { deleteAction(tag.id) }
                         )
                     }
                 }

--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -190,7 +190,7 @@ private struct PaperInformationView: View {
                         PDFTagCell(isMultiSelectable: false,
                                    isEditMode: false,
                                    tag: tag,
-                                   selectAction: {tagAction(tag.id)},
+                                   selectAction: { tagAction(tag.id) },
                                    deleteAction: {})
                     }
                 }
@@ -222,7 +222,7 @@ private struct PaperInformationView: View {
                                 PDFTagCell(isMultiSelectable: false,
                                            isEditMode: false,
                                            tag: tag,
-                                           selectAction: {tagAction(tag.id)},
+                                           selectAction: { tagAction(tag.id) },
                                            deleteAction: {})
                             }
                         }

--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-
-
 struct HomePDFCell: View {
     @State private var popover = false
     @State var paperInfo: PaperInfo
@@ -187,11 +185,13 @@ private struct PaperInformationView: View {
                     }
                 } else {
                     ForEach(getVisibleTags()) { tag in
-                        PDFTagCell(isMultiSelectable: false,
-                                   isEditMode: false,
-                                   tag: tag,
-                                   selectAction: { tagAction(tag.id) },
-                                   deleteAction: {})
+                        PDFTagCell(
+                            isMultiSelectable: false,
+                            isEditMode: false,
+                            tag: tag,
+                            selectAction: { tagAction(tag.id) },
+                            deleteAction: {}
+                        )
                     }
                 }
                 
@@ -240,6 +240,7 @@ private struct PaperInformationView: View {
     }
     
     private func getVisibleTags() -> [Tag] {
+        
         var totalWidth: CGFloat = 0
         var result = [Tag]()
         

--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -243,7 +243,10 @@ private struct PaperInformationView: View {
         var totalWidth: CGFloat = 0
         var result = [Tag]()
         
-        for tag in tags {
+        // 가나다, 알파벳 순으로 정렬
+        let sortedTags = tags.sorted(by: { $0.name < $1.name })
+        
+        for tag in sortedTags {
             let width = tag.itemWidth(isEditMode: false)
 
             if result.count < 6 && totalWidth + width <= screenWdith {
@@ -258,6 +261,7 @@ private struct PaperInformationView: View {
                 break
             }
         }
+        
         return result
     }
 }

--- a/Presentation/Home/HomeSearch/Cell/PDFTagCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/PDFTagCell.swift
@@ -10,8 +10,9 @@ import SwiftUI
 
 struct PDFTagCell<Tag: DynamicCell>: View {
     @State private var isAlertPresented: Bool = false
+    
     let isMultiSelectable: Bool      // 멀티선택 가능 여부
-    let isEditMode: Bool            // 편집 가능 여부
+    let isEditMode: Bool             // 편집 가능 여부
 
     var tag: Tag
     
@@ -30,7 +31,6 @@ struct PDFTagCell<Tag: DynamicCell>: View {
                     .reazyFont(isMultiSelectable ? .body1 : .h3)
                     .foregroundStyle(tag.isSelected ? .gray300 : .gray800)
                     .fixedSize(horizontal: true, vertical: false)
-                    .padding(.trailing, 4)
                 
                 // 삭제 버튼
                 if isEditMode {

--- a/Presentation/Home/HomeSearch/Cell/PDFTagCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/PDFTagCell.swift
@@ -41,6 +41,7 @@ struct PDFTagCell<Tag: DynamicCell>: View {
                             .foregroundStyle(.gray700)
                             .font(.system(size: 12))
                     }
+                    .padding(.leading, 4)
                 }
             }
             .frame(height: 24)

--- a/Presentation/Home/HomeView.swift
+++ b/Presentation/Home/HomeView.swift
@@ -229,6 +229,7 @@ struct HomeView: View {
                 CreateTagView()
                     .environmentObject(tagViewModel)
             }
+            
             if tagViewModel.showDeleteAlert {
                 CustomAlert(mainText: "\"\(tagViewModel.getTagName())\"\n태그를 삭제하시겠습니까?",
                             message: "해당 태그가 달린 모든 논문에서도 삭제됩니다.", width: 350, height: 173,

--- a/Presentation/Home/TagControl/TagControlView.swift
+++ b/Presentation/Home/TagControl/TagControlView.swift
@@ -25,7 +25,6 @@ struct TagControlView: View {
     let cancelAction: () -> Void
     let completeAction: () -> Void
     
-    
     var body: some View {
         ZStack {
             Color.black.opacity(0.3)
@@ -60,7 +59,9 @@ struct TagControlView: View {
                                 ForEach(paperInfo.tags) { tag in
                                     IncludedTagView(tag: tag) {
                                         viewModel.deleteTagButtonTapped(paperId: paperInfo.id, tag: tag)
-                                        paperInfo.tags.removeAll { $0.id == tag.id }
+                                        if paperInfo.tags.contains(where: { $0.id == tag.id }) {
+                                            paperInfo.tags.removeAll { $0.id == tag.id }
+                                        }
                                     }
                                 }
                             }
@@ -124,7 +125,6 @@ private struct TagInputTextField: View {
     
     @Binding var paperInfo: PaperInfo
     var textFieldFocus: FocusState<Bool>.Binding
-    
     
     var body: some View {
         ZStack {

--- a/Presentation/Home/TagControl/ViewModel/TagControlViewModel.swift
+++ b/Presentation/Home/TagControl/ViewModel/TagControlViewModel.swift
@@ -23,8 +23,8 @@ final class TagControlViewModel: ObservableObject {
     }
     private var timer: Timer?
     
-    
     private let useCase: TagControlUseCase
+    
     init(useCase: TagControlUseCase) {
         self.useCase = useCase
     }
@@ -59,9 +59,8 @@ extension TagControlViewModel {
             return nil
         }
         
-        if let firstTag = searchedTags.first, paperInfo.tags.contains(where: { $0 == firstTag }) {
-            return nil
-        }
+        if let firstTag = searchedTags.first, paperInfo.tags.contains(where: { $0 == firstTag }) { return nil }
+        
         if searchedTags.isEmpty {
             createNewTagButtonTapped()
         }
@@ -81,6 +80,7 @@ extension TagControlViewModel {
             isOverMaximumTagAlertPresented = true
             return nil
         }
+        
         if paperInfo.tags.contains(tag) { return nil }
         
         if let tag = addTagToPDF(pdfId: paperInfo.id, tagName: tag.name) {

--- a/Presentation/Home/TagSearch/SelectedTagCell.swift
+++ b/Presentation/Home/TagSearch/SelectedTagCell.swift
@@ -11,11 +11,13 @@ struct SelectedTagCell<Tag: DynamicCell>: View {
     let tag: Tag
     let action: () -> Void
     let isBtnTapped: Bool
+    
     var body: some View {
         HStack {
             Text(tag.name)
                 .reazyFont(.text1)
                 .foregroundStyle(isBtnTapped ? .gray300 : .gray800)
+
             if isBtnTapped {
                 Button {
                     action()

--- a/Presentation/Home/TagSearch/TagView.swift
+++ b/Presentation/Home/TagSearch/TagView.swift
@@ -31,34 +31,33 @@ struct TagView: View {
             
             GeometryReader { geometry in
                 VStack(spacing: 1) {
-                    HStack {
-                        if tagViewModel.isTagSelected {
-                            SelectedTagView(selectedTags: tagViewModel.selectedTags)
-                        } else {
-                            TagEmptyView()
+                    Button(action: {
+                        withAnimation {
+                            tagViewModel.isBtnTapped.toggle()
                         }
-                        
-                        Spacer()
-                        
-                        Button(action: {
-                            withAnimation {
-                                tagViewModel.isBtnTapped.toggle()
+                    }, label: {
+                        HStack {
+                            if tagViewModel.isTagSelected {
+                                SelectedTagView(selectedTags: tagViewModel.selectedTags)
+                            } else {
+                                TagEmptyView()
                             }
-                        }, label: {
+                            
+                            Spacer()
+                            
                             Image(systemName: tagViewModel.isBtnTapped ? "chevron.down" : "chevron.right")
                                 .font(.system(size: 16))
                                 .foregroundStyle(.gray600)
-                        })
-                        .frame(alignment: .trailing)
-                    }
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 15)
-                    .frame(height: 52)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(.gray100)
-                            .stroke(Color.gray400, lineWidth: 1)
-                    )
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 15)
+                        .frame(height: 52)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(.gray100)
+                                .stroke(Color.gray400, lineWidth: 1)
+                        )
+                    })
                     
                     if tagViewModel.isBtnTapped {
                         LazyVStack(alignment: .center, spacing: 0) {

--- a/Presentation/Home/TagSearch/TagViewModel.swift
+++ b/Presentation/Home/TagSearch/TagViewModel.swift
@@ -171,6 +171,7 @@ extension TagViewModel {
         self.tagFilteredPapers = self.tagViewUseCase.fetchFilteredPaperList(tags: self.selectedTags)
     }
 }
+
 struct TagPopoverPositionKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
         static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {


### PR DESCRIPTION
## 변경 사항
- [ ] 태그뷰에서 태그를 삭제했을 때, 테그셀에서 반영되지 않는 문제 해결
- [x] 태그칩 정렬 순서 문제 해결
- [x] 태그 삭제시 생기는 충돌 해결
- [x] 태그칩 좌우 여백 문제 해결
- [x] 태그 필터링 터치 영역 개선


## 스크린샷 or 영상 링크
|

https://github.com/user-attachments/assets/f54fa811-52b4-46a0-9abf-46742f2bc563


## 팀원에게 전달할 사항(Optional)
| 태그뷰 삭제시 태그셀 반영은 아직 구현되지 못했습니다. QA를 위해 현재까지 진행상황 Push하고, 다음 pr로 올리겠습니다.

1. 태그칩 정렬 문제
  태그를 추가할때마다 배열에 순서대로 append 하는데, 매번 순서가 바뀌고 규칙도 일정하지 않습니다.
  그래서 ABC, 가나다 순으로 정렬을 시켰습니다.

2. 태그 삭제시 생기는 충돌
  태그를 추가하고, 완료를 누르지 않은 상태에서 삭제를 하면 배열에 tags 배열에 추가되지 않은 상황에서 삭제됐기에 충돌이 생겼습니다.
  따라서 삭제를 눌러도 배열에 있는 있는지 확인 후 삭제되도록 했습니다.

3. 태그칩 좌우 여백 문제
  태그 편집시 생기는 x.circle이 생길때 여백을 위해 padding이 추가되어 있었습니다.
  따라서 편집을 눌러 x.circle이 생길때만, padding이 생기도록 padding 위치를 변경하여 평소에는 좌우 여백이 균일하게 했습니다.

4. 태그 필터링 터치 영역 개선
  버튼의 라벨에 네모창과 이미지를 모두 포함시켜 버튼의 영역을 개선하였습니다.


close #515 
