### PR TITLE
[Fix] 홈 뷰 관련 QA

### DIFF
--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -41,7 +41,7 @@ struct HomePDFCell: View {
                 
                 Button {
                     switch cellStatus {
-                    case .normal:
+                    case .normal, .search:
                         onTapGesture()
                     default:
                         break

--- a/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
+++ b/Presentation/Home/HomeSearch/Cell/HomePDFCell.swift
@@ -56,6 +56,7 @@ struct HomePDFCell: View {
                         )
                         
                         PaperInformationView(
+                            cellStatus: cellStatus,
                             title: paperInfo.title,
                             date: paperInfo.lastModifiedDate,
                             tags: paperInfo.tags,
@@ -140,6 +141,7 @@ private struct ThumbnailImageView: View {
 
 
 private struct PaperInformationView: View {
+    let cellStatus: CellStatus
     let title: String
     let date: Date
     let tags: [Tag]
@@ -172,7 +174,7 @@ private struct PaperInformationView: View {
             Spacer()
             
             HStack {
-                if tags.isEmpty {
+                if tags.isEmpty, cellStatus == .normal {
                     Button {
                         addAction()
                     } label: {

--- a/Presentation/Home/HomeSearch/HomeSearchView.swift
+++ b/Presentation/Home/HomeSearch/HomeSearchView.swift
@@ -101,6 +101,7 @@ private struct HomeSearchListView: View {
                             }
                         }
                     }
+                    .padding(.leading, 30)
                 }
                 .onAppear {
                     if UIDevice.current.orientation == .portrait || UIDevice.current.orientation == .portraitUpsideDown {

--- a/Presentation/Home/PaperListView.swift
+++ b/Presentation/Home/PaperListView.swift
@@ -98,7 +98,7 @@ struct PaperListView: View {
                                             HomePDFCell(
                                                 paperInfo: paperInfo,
                                                 cellStatus: homeViewModel.selectedMenu == .edit ? .selection : .normal,
-                                                screenWidth: isPortrait ? geo.size.width * 0.6 :  geo.size.width * 0.73,
+                                                screenWidth: isPortrait ? geo.size.width * 0.6 :  geo.size.width * 0.7,
                                                 onTapGesture: {
                                                     navigateToPaper(paperInfo.id)
                                                     homeViewModel.updateLastModifiedDate(at: paperInfo.id, lastModifiedDate: Date())

--- a/Presentation/OriginalPaper/Menus/Comment/ViewModel/CommentViewModel.swift
+++ b/Presentation/OriginalPaper/Menus/Comment/ViewModel/CommentViewModel.swift
@@ -485,8 +485,6 @@ extension CommentViewModel {
     }
     
     func drawUnderline(newComment: Comment) {
-        var textInputed = false
-        
         for index in newComment.pages {
             guard let page = document?.page(at: index) else { continue }
             
@@ -516,13 +514,8 @@ extension CommentViewModel {
                 
                 let underline = lineAnnotation(bounds: bounds, forType: .line, withProperties: nil)
                 
-                if textInputed {
-                    underline.setValue("UC| |" + newComment.id.uuidString, forAnnotationKey: .contents)
-                } else {
-                    let text = "UC|\(newComment.selectedText)|\(newComment.text)|\(newComment.id.uuidString)"
-                    underline.contents = text
-                    textInputed = true
-                }
+                let text = "UC|\(newComment.selectedText)|\(newComment.text)|\(newComment.id.uuidString)"
+                underline.contents = text
                 page.addAnnotation(underline)
             }
         }


### PR DESCRIPTION
## 변경 사항
- [x] 검색 결과 셀 QA 반영
- [x] PaperInfo Cell 에서 태그가 길어지는 현상 수정
- [x] 검색 결과 셀 네비게이션 수정


## 스크린샷 or 영상 링크
<img width="920" alt="스크린샷 2025-04-25 오후 1 25 59" src="https://github.com/user-attachments/assets/97f1567b-b06e-4f6d-bc17-d0f67433a8a8" />

## 추가사항
** 검색 결과 셀 수정**
검색 결과 셀에 leading padding을 주었습니다.
셀 status가 normal일 때만 셀 안에 +태그 버튼이 들어가도록 하여 검색 결과 cell에서는 나오지 않게 했습니다.

**PaperInfo Cell 에서 태그가 길어지는 현상 수정**
해당 현상을 재연을 하지 못해 일단 조건만 수정 했습니다.
기존 화면 길이 screenWidth*0.75 에서 screenWidth*0.7 로 바꾸어 태그가 길어지지 않게 수정했습니다.

**검색 결과 네비게이션 수정**
Cell에서 onTapGesture 클로저가 cellStatus == .normal 일때만 실행되도록 되어 있어 .search 일 때도 실행되게 수정했습니다.

close #517 
