### PR TITLE
[Feat] 집중 모드 시작 방식 변경

### DIFF
--- a/Data/Network/Repositories/FocusFigureRepositoryImpl.swift
+++ b/Data/Network/Repositories/FocusFigureRepositoryImpl.swift
@@ -13,6 +13,69 @@ import Vision
 
 
 class FocusFigureRepositoryImpl: FocusFigureRepository {
+    func fetchFocus(
+        process: NetworkManager.ServiceName,
+        url: URL
+    ) async -> Result<PDFLayoutResponseDTO, NetworkManagerError> {
+        guard let urlString = Bundle.main.object(forInfoDictionaryKey: "API_URL") as? String else {
+            return .failure(.invalidInfo)
+        }
+        
+        guard let requestUrl = URL(string: "https://" + urlString) else {
+            return .failure(.invalidInfo)
+        }
+        
+        guard let pdfData = try? Data(contentsOf: url) else {
+            return .failure(.invalidInfo)
+        }
+        
+        // multipart data 구분자 설정
+        let boundary = "Boundary-\(UUID().uuidString)"
+        
+        // HTTPRequest 생성
+        var request = URLRequest(url: requestUrl)
+        
+        // Header 설정
+        request.httpMethod = "POST"
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.setValue(process.rawValue, forHTTPHeaderField: "serviceName")
+        
+        // Body 설정
+        // multipart/form-data 사용
+        var body = Data()
+        let fileName = url.lastPathComponent
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(fileName)\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: application/pdf\r\n\r\n".data(using: .utf8)!)
+        body.append(pdfData)
+        body.append("\r\n".data(using: .utf8)!)
+        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+        
+        do {
+            let (data, response) = try await URLSession.shared.upload(for: request, from: body)
+            
+            if let response = response as? HTTPURLResponse {
+                // 500 error, PDF OCR 적용이 안되어있음
+                if (500 ..< 600 ~= response.statusCode) {
+                    print("PDF extract error!, statusCode: \(response.statusCode)")
+                    return .failure(.corruptedPDF)
+                }
+                
+                // 기타 요청 에러
+                else if !(200 ..< 300 ~= response.statusCode) {
+                    print("request error!, statusCode: \(response.statusCode)")
+                    return .failure(.badRequest)
+                }
+            }
+            
+            let decoder = JSONDecoder()
+            let decodedData = try decoder.decode(PDFLayoutResponseDTO.self, from: data)
+            return .success(decodedData)
+        } catch {
+            return .failure(.badRequest)
+        }
+    }
+    
     private let baseProcess: NetworkManager.ServiceName
     
     
@@ -22,7 +85,7 @@ class FocusFigureRepositoryImpl: FocusFigureRepository {
     
     
     /// 조니: 내부 CoreML을 통해서 Figure 추출 (임시로 함수 오버로드, 추후에 완벽 동작 시 코드 대체)
-    func fetchFocusAndFigures(
+    func fetchFigures(
         url: URL,
         completion: @escaping (Result<PDFLayoutResponseDTO, NetworkManagerError>) -> Void
     ) {
@@ -141,82 +204,6 @@ class FocusFigureRepositoryImpl: FocusFigureRepository {
         // 10. 최종 결과 반환
         let pdfLayout = PDFLayoutResponseDTO(div: [], fig: detectedFigures, table: nil)
         completion(.success(pdfLayout))
-    }
-    
-    
-    func fetchFocusAndFigures(
-        process: NetworkManager.ServiceName,
-        url: URL,
-        completion: @escaping (Result<PDFLayoutResponseDTO, NetworkManagerError>) -> Void
-    ) async {
-        
-        guard let urlString = Bundle.main.object(forInfoDictionaryKey: "API_URL") as? String else {
-            completion(.failure(.invalidInfo))
-            return
-        }
-        
-        guard let requestUrl = URL(string: "https://" + urlString) else {
-            completion(.failure(.invalidURL))
-            return
-        }
-        
-        guard let pdfData = try? Data(contentsOf: url) else {
-            completion(.failure(.invalidPDF))
-            return
-        }
-        
-        // multipart data 구분자 설정
-        let boundary = "Boundary-\(UUID().uuidString)"
-        
-        // HTTPRequest 생성
-        var request = URLRequest(url: requestUrl)
-        
-        // Header 설정
-        request.httpMethod = "POST"
-        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
-        request.setValue(process.rawValue, forHTTPHeaderField: "serviceName")
-        
-        // Body 설정
-        // multipart/form-data 사용
-        var body = Data()
-        let fileName = url.lastPathComponent
-        body.append("--\(boundary)\r\n".data(using: .utf8)!)
-        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"\(fileName)\"\r\n".data(using: .utf8)!)
-        body.append("Content-Type: application/pdf\r\n\r\n".data(using: .utf8)!)
-        body.append(pdfData)
-        body.append("\r\n".data(using: .utf8)!)
-        body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
-        
-        do {
-            let (data, response) = try await URLSession.shared.upload(for: request, from: body)
-            
-            if let response = response as? HTTPURLResponse {
-                // 500 error, PDF OCR 적용이 안되어있음
-                if (500 ..< 600 ~= response.statusCode) {
-                    let decoder = JSONDecoder()
-//                    let errorResult = try? decoder.decode(ErrorDescription.self, from: data)
-                    print("PDF extract error!, statusCode: \(response.statusCode)")
-//                    print(errorResult.error)
-                    completion(.failure(.corruptedPDF))
-                    return
-                }
-                
-                // 기타 요청 에러
-                else if !(200 ..< 300 ~= response.statusCode) {
-                    print("request error!, statusCode: \(response.statusCode)")
-                    completion(.failure(.badRequest))
-                    return
-                }
-            }
-            
-            let decoder = JSONDecoder()
-            let decodedData = try decoder.decode(PDFLayoutResponseDTO.self, from: data)
-            completion(.success(decodedData))
-        } catch {
-            print(String(describing: error))
-        }
-        
-        
     }
     
     /// 에러 메시지 모델

--- a/Domain/Interfaces/Repositories/FocusFigureRepository.swift
+++ b/Domain/Interfaces/Repositories/FocusFigureRepository.swift
@@ -11,11 +11,13 @@ import PDFKit
 
 
 protocol FocusFigureRepository {
-    func fetchFocusAndFigures (
-        process: NetworkManager.ServiceName,
+    func fetchFigures(
         url: URL,
         completion: @escaping (Result<PDFLayoutResponseDTO, NetworkManagerError>) -> Void
     ) async
     
-    func fetchFocusAndFigures(url: URL, completion: @escaping (Result<PDFLayoutResponseDTO, NetworkManagerError>) -> Void) async
+    func fetchFocus(
+        process: NetworkManager.ServiceName,
+        url: URL
+    ) async -> Result<PDFLayoutResponseDTO, NetworkManagerError>
 }

--- a/Domain/UseCases/FocusFigureUseCase.swift
+++ b/Domain/UseCases/FocusFigureUseCase.swift
@@ -12,11 +12,14 @@ import PDFKit
 protocol FocusFigureUseCase {
     var pdfSharedData: PDFSharedData { get set }
     
-    func excute(
-        process: NetworkManager.ServiceName,
+    func excuteFigures(
         url: URL,
         completion: @escaping (Result<PDFLayoutResponseDTO, NetworkManagerError>) -> Void
     ) async
+    
+    func excuteFocus(
+        url: URL
+    ) async -> Result<PDFLayoutResponseDTO, any Error>
     
     func stopTask()
     
@@ -90,13 +93,12 @@ class DefaultFocusFigureUseCase: FocusFigureUseCase {
         self.collectionDataRepository = collectionDataRepository
     }
     
-    public func excute(
-        process: NetworkManager.ServiceName,
+    public func excuteFigures(
         url: URL,
         completion: @escaping (Result<PDFLayoutResponseDTO, NetworkManagerError>) -> Void
     ) async {
         self.currentTask = Task {
-            await self.focusFigureRepository.fetchFocusAndFigures(url: url) { result in
+            await self.focusFigureRepository.fetchFigures(url: url) { result in
                 switch result {
                 case .success(let layout):
                     completion(.success(layout))
@@ -104,6 +106,16 @@ class DefaultFocusFigureUseCase: FocusFigureUseCase {
                     completion(.failure(error))
                 }
             }
+        }
+    }
+    
+    public func excuteFocus(url: URL) async -> Result<PDFLayoutResponseDTO, any Error> {
+        let result = await self.focusFigureRepository.fetchFocus(process: .processFulltextDocument, url: url)
+        switch result {
+        case .success(let layout):
+            return .success(layout)
+        case .failure(let failure):
+            return .failure(failure)
         }
     }
     

--- a/Presentation/ConcentratePaper/ConcentrateViewController.swift
+++ b/Presentation/ConcentratePaper/ConcentrateViewController.swift
@@ -34,6 +34,9 @@ final class ConcentrateViewController: UIViewController {
 //        guard let page = self.viewModel.focusDocument?.page(at: focusPageNum ?? 0) else { return }
 //        self.pdfView.go(to: page)
         
+//        if let isFigureSaved = PDFSharedData.shared.paperInfo?.isFigureSaved, !isFigureSaved {
+//            viewModel.downloadFocusFigure(inOriginal: false)
+//        }
     }
     
     lazy var pdfView: PDFView = {

--- a/Presentation/ConcentratePaper/ConcentrateViewController.swift
+++ b/Presentation/ConcentratePaper/ConcentrateViewController.swift
@@ -29,14 +29,13 @@ final class ConcentrateViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        // TODO: 추후 수정 예정
-//        let focusPageNum = self.viewModel.focusAnnotations.firstIndex { $0.page == self.viewModel.changedPageNumber + 1}
-//        guard let page = self.viewModel.focusDocument?.page(at: focusPageNum ?? 0) else { return }
-//        self.pdfView.go(to: page)
-        
-//        if let isFigureSaved = PDFSharedData.shared.paperInfo?.isFigureSaved, !isFigureSaved {
-//            viewModel.downloadFocusFigure(inOriginal: false)
-//        }
+        if viewModel.isFirstUpload {
+            Task {
+                await viewModel.downloadFocus {
+                    self.setData()
+                }
+            }
+        }
     }
     
     lazy var pdfView: PDFView = {

--- a/Presentation/MainPDF/MainPDFView.swift
+++ b/Presentation/MainPDF/MainPDFView.swift
@@ -482,17 +482,20 @@ struct MainPDFView: View {
         .blur(radius: homeViewModel.viewStatus != .normal ? 5 : 0)
         .overlay {
             if self.focusFigureViewModel.figureStatus == .loading {
-                FigureLoadingView()
+                FigureLoadingView(isOriginal: true)
+            } else if self.focusFigureViewModel.focusStatus == .loading {
+                FigureLoadingView(isOriginal: false)
             }
             
-            if case let .search(paper) = homeViewModel.viewStatus {
-                RenamePaperTitleView(paperInfo: paper) {
-                    homeViewModel.viewStatus = .normal
-                } completeAction: { text in
-                    homeViewModel.updateTitle(at: paper.id, title: text) {
-                        if !$0 { isDuplicatedTitleAlertPresented.toggle() }
+            if self.focusFigureViewModel.focusStatus == .networkDisconnection {
+                ZStack {
+                    Color.gray900
+                        .opacity(0.4)
+                        .ignoresSafeArea()
+                    
+                    NetworkDisconnectionAlert {
+                        focusFigureViewModel.focusStatus = .beforeStart
                     }
-                    homeViewModel.viewStatus = .normal
                 }
             }
             
@@ -829,6 +832,8 @@ private struct FigureLoadingView: View {
     @State private var timer: Timer?
     @State private var loadingTextFlag: Bool = false
     
+    let isOriginal: Bool
+    
     var body: some View {
         ZStack {
             Color.gray900
@@ -845,9 +850,16 @@ private struct FigureLoadingView: View {
                     .tint(.primary1)
                     .frame(width: 16)
                 
-                Text( self.loadingTextFlag ? "Figure 추출은 10초 ~ 20초 정도 소요됩니다" : "Figure와 Table을 불러오는 중입니다")
-                    .reazyFont(.body1)
-                    .foregroundStyle(.primary1)
+                if isOriginal {
+                    Text( self.loadingTextFlag ? "Figure 추출은 10초 ~ 20초 정도 소요됩니다" : "Figure와 Table을 불러오는 중입니다" )
+                        .reazyFont(.body1)
+                        .foregroundStyle(.primary1)
+                } else {
+                    Text( self.loadingTextFlag ? "집중모드를 활성화 중입니다" : "집중모드는 논문을 한 단으로\n정렬하는 읽기전용 모드입니다" )
+                        .reazyFont(.body1)
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(.primary1)
+                }
             }
         }
         .onAppear {
@@ -858,5 +870,41 @@ private struct FigureLoadingView: View {
         .onDisappear {
             self.timer?.invalidate()
         }
+    }
+}
+
+private struct NetworkDisconnectionAlert: View {
+    let completeAction: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("집중모드 활성화를 위해\n네트워크 연결이 필요합니다")
+                .reazyFont(.button1)
+                .foregroundStyle(.gray900)
+                .multilineTextAlignment(.center)
+                .padding(.top, 36)
+                .padding(.horizontal, 30)
+            
+            Spacer()
+            
+            Rectangle()
+                .frame(height: 1)
+                .foregroundStyle(.gray400)
+            
+            Button {
+                completeAction()
+            } label: {
+                Text("취소")
+                    .reazyFont(.h3)
+                    .foregroundStyle(.primary1)
+                    .frame(width: 300, height: 52)
+            }
+
+        }
+        .frame(width: 340, height: 163)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .foregroundStyle(.gray200)
+        )
     }
 }

--- a/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureView.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureView.swift
@@ -23,9 +23,6 @@ struct FigureView: View {
                 case .beforeStart:
                     FigureBeforeStartView()
                     
-                case .networkDisconnection:
-                    FigureNetworkDisconnectionView()
-                    
                 case .loading:
                     Text("Figure와 Table이 있으면,\n여기에 표시됩니다")
                         .multilineTextAlignment(.center)
@@ -37,13 +34,6 @@ struct FigureView: View {
                 }
             }
         }
-    }
-    
-    enum FigureStatus {
-        case networkDisconnection
-        case loading
-        case empty
-        case complete
     }
 }
 

--- a/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureView.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureView.swift
@@ -59,7 +59,7 @@ private struct FigureBeforeStartView: View {
             .multilineTextAlignment(.center)
         
         Button {
-            focusFigureViewModel.downloadFocusFigure()
+            focusFigureViewModel.downloadFigure()
         } label: {
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
@@ -88,7 +88,7 @@ private struct FigureNetworkDisconnectionView: View {
                 .foregroundStyle(.gray600)
             
             Button {
-                focusFigureViewModel.downloadFocusFigure()
+                focusFigureViewModel.downloadFigure()
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 8)
@@ -197,7 +197,7 @@ private struct FigureCompleteView: View {
                     .foregroundStyle(.gray600)
                 
                 Button {
-                    focusFigureViewModel.downloadFocusFigure()
+                    focusFigureViewModel.downloadFigure()
                 } label: {
                     ZStack {
                         RoundedRectangle(cornerRadius: 8)

--- a/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
@@ -32,6 +32,7 @@ class FocusFigureViewModel: ObservableObject {
     @Published public var figureDocuments: [PDFDocument] = []
     @Published public var collectionDocuments: [PDFDocument] = []
     @Published public var figureStatus: FigureStatus = .beforeStart
+    @Published public var focusStatus: FocusStatus = .beforeStart
     @Published public var changedPageNumber: Int = 0
     
     @Published public var isEditFigName: Bool = false
@@ -45,6 +46,20 @@ class FocusFigureViewModel: ObservableObject {
     let collectionPublisher = NotificationCenter.default.publisher(for: .isCollectionCaptured)
     let figureUpdatedPublisher = PassthroughSubject<FigureAnnotation, Never>()
     let collectionUpdatedPublisher = PassthroughSubject<FigureAnnotation, Never>()
+    public var isFirstUpload: Bool {
+        if PDFSharedData.shared.paperInfo?.focusURL == nil {
+            return true
+        } else {
+            return false
+//            var stale = false
+//            let data = PDFSharedData.shared.paperInfo!.focusURL!
+//            if let _ = try? URL.init(resolvingBookmarkData: data, bookmarkDataIsStale: &stale) {
+//               return false
+//            } else {
+//                return true
+//            }
+        }
+    }
     
     var cancellables: Set<AnyCancellable> = []
     private var focusFigureUseCase: FocusFigureUseCase
@@ -118,7 +133,10 @@ extension FocusFigureViewModel {
         self.focusFigureUseCase.pdfSharedData.document
     }
     
-    public func downloadFocus() async {
+    public func downloadFocus(completion: @escaping () -> Void) async {
+        if self.focusStatus == .loading { return }
+        
+        self.focusStatus = .loading
         let isNetworkConneted = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
             NWPathMonitor().startMonitoring {
                 if $0 { continuation.resume(returning: true) }
@@ -127,7 +145,7 @@ extension FocusFigureViewModel {
         }
         
         if !isNetworkConneted {
-            self.figureStatus = .networkDisconnection
+            self.focusStatus = .networkDisconnection
             return
         }
         
@@ -136,28 +154,26 @@ extension FocusFigureViewModel {
         guard let url = try? URL.init(
             resolvingBookmarkData: self.focusFigureUseCase.pdfSharedData.paperInfo!.url,
             bookmarkDataIsStale: &isStale) else {
+            self.focusStatus = .empty
             return
         }
         
-        Task.init {
-            let height = self.focusFigureUseCase.getPDFHeight()
-            var paperInfo = self.focusFigureUseCase.pdfSharedData.paperInfo!
-            
-            let result = await self.focusFigureUseCase.excuteFocus(url: url)
-            
-            switch result {
-            case .success(let layout):
-                self.figures = layout.toFigureEntities(pageHeight: height)
-                self.focusPages = layout.toFocusEntities(pageHeight: height)
-                
+        let height = self.focusFigureUseCase.getPDFHeight()
+        var paperInfo = self.focusFigureUseCase.pdfSharedData.paperInfo!
+        
+        let result = await self.focusFigureUseCase.excuteFocus(url: url)
+        
+        switch result {
+        case .success(let layout):
+            self.figures = layout.toFigureEntities(pageHeight: height)
+            self.focusPages = layout.toFocusEntities(pageHeight: height)
                 self.focusFigureUseCase.makeFocusDocument(
                     focusAnnotations: self.focusPages,
                     fileName: paperInfo.title) {
                         if !$1 {
-                            self.focusFigureUseCase.pdfSharedData.paperInfo!.isFigureSaved = true
-                            paperInfo.isFigureSaved = true
+                            paperInfo.focusURL = .init()
                             self.focusFigureUseCase.editPaperInfo(info: paperInfo)
-                            self.figureStatus = .empty
+                            self.focusStatus = .empty
                             return
                         }
                         
@@ -167,27 +183,24 @@ extension FocusFigureViewModel {
                         
                         self.focusFigureUseCase.pdfSharedData.paperInfo!.focusURL = focusURLData
                         paperInfo.focusURL = focusURLData
+                        
+                        self.saveFigures(figures: layout.toCoreData())
+                        self.focusFigureUseCase.editPaperInfo(info: paperInfo)
+                        DispatchQueue.main.async {
+                            self.focusStatus = .complete
+                            completion()
+                        }
                     }
-                
-                self.focusFigureUseCase.pdfSharedData.paperInfo!.isFigureSaved = true
-                paperInfo.isFigureSaved = true
-                
-                self.saveFigures(figures: layout.toCoreData())
-                self.focusFigureUseCase.editPaperInfo(info: paperInfo)
-                
-                DispatchQueue.main.async {
-                    self.figureStatus = .complete
-                }
-            case .failure(let failure):
-                //                        self.focusFigureUseCase.pdfSharedData.paperInfo!.isFigureSaved = true
-                //                        paperInfo.isFigureSaved = true
-                //                        self.focusFigureUseCase.editPaperInfo(info: paperInfo)
-                //
-                //                        DispatchQueue.main.async {
-                //                            self.figureStatus = .empty
-                //                            print(error)
-                //                        }
-                break
+        case .failure(let error):
+            paperInfo.isFigureSaved = true
+            paperInfo.focusURL = .init()
+            
+            PDFSharedData.shared.paperInfo?.focusURL = .init()
+            
+            self.focusFigureUseCase.editPaperInfo(info: paperInfo)
+            DispatchQueue.main.async {
+                self.focusStatus = .empty
+                print(error)
             }
         }
     }
@@ -344,8 +357,15 @@ extension FocusFigureViewModel {
     
     enum FigureStatus {
         case beforeStart
-        case networkDisconnection
         case loading
+        case empty
+        case complete
+    }
+    
+    enum FocusStatus {
+        case beforeStart
+        case loading
+        case networkDisconnection
         case empty
         case complete
     }

--- a/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
@@ -51,13 +51,6 @@ class FocusFigureViewModel: ObservableObject {
             return true
         } else {
             return false
-//            var stale = false
-//            let data = PDFSharedData.shared.paperInfo!.focusURL!
-//            if let _ = try? URL.init(resolvingBookmarkData: data, bookmarkDataIsStale: &stale) {
-//               return false
-//            } else {
-//                return true
-//            }
         }
     }
     

--- a/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
@@ -118,91 +118,132 @@ extension FocusFigureViewModel {
         self.focusFigureUseCase.pdfSharedData.document
     }
     
+    public func downloadFocus() async {
+        let isNetworkConneted = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            NWPathMonitor().startMonitoring {
+                if $0 { continuation.resume(returning: true) }
+                else { continuation.resume(returning: false) }
+            }
+        }
+        
+        if !isNetworkConneted {
+            self.figureStatus = .networkDisconnection
+            return
+        }
+        
+        var isStale: Bool = false
+        
+        guard let url = try? URL.init(
+            resolvingBookmarkData: self.focusFigureUseCase.pdfSharedData.paperInfo!.url,
+            bookmarkDataIsStale: &isStale) else {
+            return
+        }
+        
+        Task.init {
+            let height = self.focusFigureUseCase.getPDFHeight()
+            var paperInfo = self.focusFigureUseCase.pdfSharedData.paperInfo!
+            
+            let result = await self.focusFigureUseCase.excuteFocus(url: url)
+            
+            switch result {
+            case .success(let layout):
+                self.figures = layout.toFigureEntities(pageHeight: height)
+                self.focusPages = layout.toFocusEntities(pageHeight: height)
+                
+                self.focusFigureUseCase.makeFocusDocument(
+                    focusAnnotations: self.focusPages,
+                    fileName: paperInfo.title) {
+                        if !$1 {
+                            self.focusFigureUseCase.pdfSharedData.paperInfo!.isFigureSaved = true
+                            paperInfo.isFigureSaved = true
+                            self.focusFigureUseCase.editPaperInfo(info: paperInfo)
+                            self.figureStatus = .empty
+                            return
+                        }
+                        
+                        self.focusDocument = PDFDocument(url: $0!)
+                        
+                        let focusURLData = try? $0!.bookmarkData(options: .minimalBookmark)
+                        
+                        self.focusFigureUseCase.pdfSharedData.paperInfo!.focusURL = focusURLData
+                        paperInfo.focusURL = focusURLData
+                    }
+                
+                self.focusFigureUseCase.pdfSharedData.paperInfo!.isFigureSaved = true
+                paperInfo.isFigureSaved = true
+                
+                self.saveFigures(figures: layout.toCoreData())
+                self.focusFigureUseCase.editPaperInfo(info: paperInfo)
+                
+                DispatchQueue.main.async {
+                    self.figureStatus = .complete
+                }
+            case .failure(let failure):
+                //                        self.focusFigureUseCase.pdfSharedData.paperInfo!.isFigureSaved = true
+                //                        paperInfo.isFigureSaved = true
+                //                        self.focusFigureUseCase.editPaperInfo(info: paperInfo)
+                //
+                //                        DispatchQueue.main.async {
+                //                            self.figureStatus = .empty
+                //                            print(error)
+                //                        }
+                break
+            }
+        }
+    }
     
-    public func downloadFocusFigure() {
+    public func downloadFigure() {
         if self.figureStatus == .loading { return }
         
         var paperInfo = self.focusFigureUseCase.pdfSharedData.paperInfo
         
         paperInfo?.isFigureSaved = true
         
-        NWPathMonitor().startMonitoring { isConnected in
-            if !isConnected {
-                DispatchQueue.main.async {
-                    self.figureStatus = .networkDisconnection
-                }
-                return
+        self.figureStatus = .loading
+        
+        var isStale = false
+        
+        guard let url = try? URL.init(
+            resolvingBookmarkData: self.focusFigureUseCase.pdfSharedData.paperInfo!.url,
+            bookmarkDataIsStale: &isStale) else {
+            return
+        }
+        
+        let accessed = url.startAccessingSecurityScopedResource()
+        // startAccessing이 실패해도 그냥 쓸 수 있게 guard 문에서 빼서 처리
+        defer {
+            if accessed {
+                url.stopAccessingSecurityScopedResource()
             }
+        }
+        
+        Task.init {
+            let height = self.focusFigureUseCase.getPDFHeight()
+            var paperInfo = self.focusFigureUseCase.pdfSharedData.paperInfo!
             
-            DispatchQueue.main.async {
-                self.figureStatus = .loading
-            }
-            
-            var isStale = false
-            
-            guard let url = try? URL.init(
-                resolvingBookmarkData: self.focusFigureUseCase.pdfSharedData.paperInfo!.url,
-                bookmarkDataIsStale: &isStale) else {
-                return
-            }
-            
-            let accessed = url.startAccessingSecurityScopedResource()
-            // startAccessing이 실패해도 그냥 쓸 수 있게 guard 문에서 빼서 처리
-            defer {
-                if accessed {
-                    url.stopAccessingSecurityScopedResource()
-                }
-            }
-            
-            Task.init {
-                let height = self.focusFigureUseCase.getPDFHeight()
-                var paperInfo = self.focusFigureUseCase.pdfSharedData.paperInfo!
-                
-                await self.focusFigureUseCase.excute(process: .processFulltextDocument, url: url) {
-                    switch $0 {
-                    case .success(let layout):
-                        DispatchQueue.main.async {
-                            self.figures = layout.toFigureEntities(pageHeight: height)
-//                            self.focusPages = layout.toFocusEntities(pageHeight: height)
-//                            
-//                            self.focusFigureUseCase.makeFocusDocument(
-//                                focusAnnotations: self.focusPages,
-//                                fileName: paperInfo.title) {
-//                                    if !$1 {
-//                                        self.focusFigureUseCase.pdfSharedData.paperInfo!.isFigureSaved = true
-//                                        paperInfo.isFigureSaved = true
-//                                        self.focusFigureUseCase.editPaperInfo(info: paperInfo)
-//                                        self.figureStatus = .empty
-//                                        return
-//                                    }
-//                                    
-//                                    self.focusDocument = PDFDocument(url: $0!)
-//
-//                                    let focusURLData = try? $0!.bookmarkData(options: .minimalBookmark)
-//
-//                                    self.focusFigureUseCase.pdfSharedData.paperInfo!.focusURL = focusURLData
-//                                    paperInfo.focusURL = focusURLData
-//                                }
-                            
-                            self.focusFigureUseCase.pdfSharedData.paperInfo!.isFigureSaved = true
-                            paperInfo.isFigureSaved = true
-                            
-                            self.saveFigures(figures: layout.toCoreData())
-                            self.focusFigureUseCase.editPaperInfo(info: paperInfo)
-                            
-                            DispatchQueue.main.async {
-                                self.figureStatus = .complete
-                            }
-                        }
-                    case .failure(let error):
+            await self.focusFigureUseCase.excuteFigures(url: url) {
+                switch $0 {
+                case .success(let layout):
+                    DispatchQueue.main.async {
+                        self.figures = layout.toFigureEntities(pageHeight: height)
                         self.focusFigureUseCase.pdfSharedData.paperInfo!.isFigureSaved = true
                         paperInfo.isFigureSaved = true
+                        
+                        self.saveFigures(figures: layout.toCoreData())
                         self.focusFigureUseCase.editPaperInfo(info: paperInfo)
                         
                         DispatchQueue.main.async {
-                            self.figureStatus = .empty
-                            print(error)
+                            self.figureStatus = .complete
                         }
+                    }
+                case .failure(let error):
+                    self.focusFigureUseCase.pdfSharedData.paperInfo!.isFigureSaved = true
+                    paperInfo.isFigureSaved = true
+                    self.focusFigureUseCase.editPaperInfo(info: paperInfo)
+                    
+                    DispatchQueue.main.async {
+                        self.figureStatus = .empty
+                        print(error)
                     }
                 }
             }


### PR DESCRIPTION
## 변경 사항
- [x] 집중 모드 시작 방식 변경(집중 모드를 처음 들어갔을 때 시작)
- [x] 네트워크 연결 실패 alert 추가
- [x] 피규어 추출, 집중모드 메소드 분리 및 불필요한 코드 제거


## 스크린샷 or 영상 링크
**집중모드 시작**

https://github.com/user-attachments/assets/8a01bda1-6222-4cab-a302-22bb42966ead


## 팀원에게 전달할 사항(Optional)
**피규어 추출, 집중모드 메소드 분리 및 불필요한 코드 제거**
이제 내장된 모델로 피규어를 추출하므로 네트워크 통신이 필요하지 않으므로 같이 진행되던 피규어 추출과 집중모드 추출 메소드를 분리했습니다.
분리함과 동시에 각자에 메소드에 맞게 필요없는 코드들은 삭제를 진행했습니다(피규어 추출 -> 네트워크 통신 확인 필요 x, 삭제)

**집중 모드 시작 방식 변경(집중 모드를 처음 들어갔을 때 시작)**
원래는 피규어 추출을 누르면 집중모드도 같이 되게 할려고 했는데 메소드를 분리함에 따라 그 부분이 어려워저 집중 모드 시작 트리거를 집중모드를 들어갔을 때로 변경하게되었습니다.

close #487 
