### PR TITLE
[Feat] 맥 기능 기반 트러블 슈팅

### DIFF
--- a/Data/CoreData/PersistantContainer.swift
+++ b/Data/CoreData/PersistantContainer.swift
@@ -42,7 +42,7 @@ final class PersistantContainer {
                     try coordinator.destroyPersistentStore(at: storeURL, ofType: store.type, options: nil)
                 }
             } catch {
-                print("Failed to reset Core Data: \(error.localizedDescription)")
+                log("Failed to reset Core Data: \(error.localizedDescription)")
             }
         }
         

--- a/Data/CoreData/Repositories/CollectionDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/CollectionDataRepositoryImpl.swift
@@ -59,7 +59,7 @@ final class CollectionDataRepositoryImpl: CollectionDataRepository {
                         try context.save()
                         result = .success(.init())
                     } catch {
-                        print(String(describing: error))
+                        log(String(describing: error))
                         result = .failure(error)
                     }
                 } else {

--- a/Data/CoreData/Repositories/FigureDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/FigureDataRepositoryImpl.swift
@@ -60,7 +60,7 @@ final class FigureDataRepositoryImpl: FigureDataRepository {
                         try context.save()
                         result = .success(.init())
                     } catch {
-                        print(String(describing: error))
+                        log(String(describing: error))
                         result = .failure(error)
                     }
                 } else {

--- a/Data/CoreData/Repositories/PaperDataRepositoryImpl.swift
+++ b/Data/CoreData/Repositories/PaperDataRepositoryImpl.swift
@@ -206,7 +206,7 @@ final class PaperDataRepositoryImpl: PaperDataRepository {
                 return .failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Data not found"]))
             }
         } catch {
-            print(error)
+            log(error)
             return .failure(error)
         }
     }

--- a/Data/CoreData/Repositories/PaperDataRepositoryTagImpl.swift
+++ b/Data/CoreData/Repositories/PaperDataRepositoryTagImpl.swift
@@ -204,7 +204,7 @@ final class PaperDataRepositoryTagImpl: PaperDataRepository {
                 return .failure(NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Data not found"]))
             }
         } catch {
-            print(error)
+            log(error)
             return .failure(error)
         }
     }

--- a/Data/Extension/FileManager + Extension.swift
+++ b/Data/Extension/FileManager + Extension.swift
@@ -20,7 +20,7 @@ extension FileManager {
         do {
             try moveItem(at: fileURL, to: newUrl)
         } catch {
-            print(error)
+            log(error)
             return false
         }
         

--- a/Data/Network/Repositories/FocusFigureRepositoryImpl.swift
+++ b/Data/Network/Repositories/FocusFigureRepositoryImpl.swift
@@ -57,13 +57,13 @@ class FocusFigureRepositoryImpl: FocusFigureRepository {
             if let response = response as? HTTPURLResponse {
                 // 500 error, PDF OCR 적용이 안되어있음
                 if (500 ..< 600 ~= response.statusCode) {
-                    print("PDF extract error!, statusCode: \(response.statusCode)")
+                    log("PDF extract error!, statusCode: \(response.statusCode)")
                     return .failure(.corruptedPDF)
                 }
                 
                 // 기타 요청 에러
                 else if !(200 ..< 300 ~= response.statusCode) {
-                    print("request error!, statusCode: \(response.statusCode)")
+                    log("request error!, statusCode: \(response.statusCode)")
                     return .failure(.badRequest)
                 }
             }

--- a/Domain/Interfaces/PDFSharedData.swift
+++ b/Domain/Interfaces/PDFSharedData.swift
@@ -33,7 +33,7 @@ class PDFSharedData {
             self.paperInfo = paperInfo
             
         } catch {
-            print("Failed to make Document \(#function)")
+            log("Failed to make Document \(#function)")
         }
     }
     

--- a/Domain/UseCases/HomeSearchUseCase.swift
+++ b/Domain/UseCases/HomeSearchUseCase.swift
@@ -179,7 +179,7 @@ extension DefaultHomeSearchUseCase {
                 }
             }
         } catch {
-            print("error copying file: \(error)")
+            log("error copying file: \(error)")
         }
         
         return nil

--- a/Domain/UseCases/HomeViewUseCase.swift
+++ b/Domain/UseCases/HomeViewUseCase.swift
@@ -403,7 +403,7 @@ class DefaultHomeViewUseCase: HomeViewUseCase {
             
             return (urlData, fileURL)
         } catch {
-            print("error copying file: \(error)")
+            log("error copying file: \(error)")
         }
         
         return nil
@@ -470,7 +470,7 @@ class DefaultHomeViewUseCase: HomeViewUseCase {
                 }
             }
         } catch {
-            print("error copying file: \(error)")
+            log("error copying file: \(error)")
         }
         
         return nil

--- a/Domain/UseCases/TagViewUseCase.swift
+++ b/Domain/UseCases/TagViewUseCase.swift
@@ -193,7 +193,7 @@ extension DefaultTagViewUseCase {
                 }
             }
         } catch {
-            print("error copying file: \(error)")
+            log("error copying file: \(error)")
         }
         
         return nil

--- a/Presentation/AppView.swift
+++ b/Presentation/AppView.swift
@@ -107,7 +107,7 @@ extension AppView {
             
             if let appStoreVersion = results[0]["version"] as? String {
                 if currentVersion != appStoreVersion {
-                    print("🔔Current Version: \(currentVersion), App Store Version: \(appStoreVersion)")
+                    log("🔔Current Version: \(currentVersion), App Store Version: \(appStoreVersion)")
                     self.isUpdateAlertPresented.toggle()
                 }
             }

--- a/Presentation/Helper/Logger.swift
+++ b/Presentation/Helper/Logger.swift
@@ -1,0 +1,23 @@
+//
+//  Logger.swift
+//  Reazy
+//
+//  Created by 문인범 on 12/1/25.
+//
+
+import Foundation
+
+/**
+ 기존 print 메소드에서 호출된 파일, 라인, 메소드명이 추가되어 출력됩니다.
+ */
+public func log(
+    _ message: @autoclosure () -> Any,
+    fileName: String = #fileID,
+    line: Int = #line,
+    function: String = #function ) {
+        print("""
+            \(Date()) \(fileName), line: \(line)
+            \(function)
+            \(message())
+            """)
+}

--- a/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
+++ b/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
@@ -103,7 +103,7 @@ extension HomeSearchViewModel {
         if case .success = response {
             loadSearchedList()
         } else {
-            print(#function)
+            log(#function)
         }
     }
 }
@@ -117,7 +117,7 @@ extension HomeSearchViewModel {
         case .success(let papers):
            self.fetchSearchList(papers: papers)
         case .failure:
-            print(#function)
+            log(#function)
         }
         self.toggleIsLoading(false)
     }

--- a/Presentation/Home/HomeView.swift
+++ b/Presentation/Home/HomeView.swift
@@ -398,10 +398,10 @@ private struct MainMenuView: View {
             if let newPaperID = homeViewModel.uploadPDF(url: url) {
                 homeViewModel.selectedItemID = newPaperID
             } else {
-                print("Duplicated File Name")
+                log("Duplicated File Name")
             }
         case .failure(let error):
-            print(String(describing: error))
+            log(String(describing: error))
         }
     }
 }

--- a/Presentation/Home/SettingView.swift
+++ b/Presentation/Home/SettingView.swift
@@ -170,7 +170,7 @@ private struct SupportEmail {
         guard let url = URL(string: urlString) else { return }
         openURL(url) { accepted in
             if !accepted {
-                print("ERROR: 현재 기기는 이메일을 지원하지 않습니다.")
+                log("ERROR: 현재 기기는 이메일을 지원하지 않습니다.")
             }
         }
     }

--- a/Presentation/Home/TagSearch/TagViewModel.swift
+++ b/Presentation/Home/TagSearch/TagViewModel.swift
@@ -154,7 +154,7 @@ extension TagViewModel {
         if case .success = response {
             fetchFilteredPaperList()
         } else {
-            print(#function)
+            log(#function)
         }
     }
     

--- a/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -118,7 +118,7 @@ class HomeViewModel: ObservableObject {
         case .success(let paperInfos):
             self.paperInfos = paperInfos
         case .failure(let error):
-            print(error)
+            log(error)
             return
         }
         
@@ -171,7 +171,7 @@ extension HomeViewModel {
             }
             return paperInfo?.id
         } catch {
-            print(error)
+            log(error)
             return nil
         }
     }
@@ -198,7 +198,7 @@ extension HomeViewModel {
                 self.paperInfos.append(result)
             }
         } catch {
-            print(error)
+            log(error)
         }
     }
     
@@ -254,7 +254,7 @@ extension HomeViewModel {
                 
                 completion(true)
             case .failure(let error):
-                print(error)
+                log(error)
                 completion(false)
             }
         }
@@ -346,7 +346,7 @@ extension HomeViewModel {
         case let .success(folders):
             self.folders = folders
         case let .failure(error):
-            print(error)
+            log(error)
         }
     }
     
@@ -582,14 +582,14 @@ extension HomeViewModel {
         let data = selectedPaper.url
         
         guard let url = try? URL.init(resolvingBookmarkData: data, bookmarkDataIsStale: &isStale) else {
-            print("bookmarkdata to url failed")
+            log("bookmarkdata to url failed")
             return
         }
         
         if isStale {
-            print("Bookmark(\(url.lastPathComponent)) is stale")
+            log("Bookmark(\(url.lastPathComponent)) is stale")
             guard let newURL = try? url.bookmarkData(options: .suitableForBookmarkFile) else {
-                print("Unable to create bookmark")
+                log("Unable to create bookmark")
                 return
             }
             

--- a/Presentation/MainPDF/MainPDFView.swift
+++ b/Presentation/MainPDF/MainPDFView.swift
@@ -396,7 +396,7 @@ struct MainPDFView: View {
                 mainPDFViewModel.statusStack.isDetailSelected
                 ? DragGesture(minimumDistance: 0)
                     .onChanged { _ in
-                        print("터치 감지됨!")
+                        log("터치 감지됨!")
                         mainPDFViewModel.statusStack.detailOff()
                     }
                 : nil

--- a/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
+++ b/Presentation/MainPDF/ViewModel/MainPDFViewModel.swift
@@ -133,7 +133,7 @@ extension MainPDFViewModel {
         guard let document = pdfView.document else { return }
         // TODO: 이름 변경시에 URL도 바뀌어야 하는게 아닌가?
         guard let pdfURL = PDFSharedData.shared.paperInfo?.url, let url = try? URL(resolvingBookmarkData: pdfURL, bookmarkDataIsStale: &a) else {
-            print("PDF URL을 찾을 수 없습니다.")
+            log("PDF URL을 찾을 수 없습니다.")
             throw HomeViewError.cannotCreateBookmark
         }
         
@@ -153,9 +153,9 @@ extension MainPDFViewModel {
             let pdfData = document.dataRepresentation()
             try pdfData?.write(to: url)
             
-            print("PDF 저장이 완료되었습니다.")
+            log("PDF 저장이 완료되었습니다.")
         } catch {
-            print("PDF 저장 중 오류 발생: \(error.localizedDescription)")
+            log("PDF 저장 중 오류 발생: \(error.localizedDescription)")
         }
     }
     
@@ -268,7 +268,7 @@ extension MainPDFViewModel {
             self.mainPDFViewAction = .none
         case .failure(let error):
             self.mainPDFViewAction = .duplicatedTitleAlert
-            print(error)
+            log(error)
         }
     }
 }

--- a/Presentation/MainPDF/ViewModel/PDFInfoMenuViewModel.swift
+++ b/Presentation/MainPDF/ViewModel/PDFInfoMenuViewModel.swift
@@ -89,9 +89,9 @@ class PDFInfoMenuViewModel: ObservableObject {
             let pdfData = document.dataRepresentation()
             try pdfData?.write(to: self.fileURL)
             
-            print("PDF 저장이 완료되었습니다.")
+            log("PDF 저장이 완료되었습니다.")
         } catch {
-            print("PDF 저장 중 오류 발생: \(error.localizedDescription)")
+            log("PDF 저장 중 오류 발생: \(error.localizedDescription)")
         }
     }
 }

--- a/Presentation/OriginalPaper/Floating/FloatingSplitView.swift
+++ b/Presentation/OriginalPaper/Floating/FloatingSplitView.swift
@@ -105,7 +105,7 @@ struct FloatingSplitView: View {
                                 floatingViewModel.saveFigAlert()
                                 self.isSavedLocation = true
                                 
-                                print("Download Image")
+                                log("Download Image")
                                 
                             }, label: {
                                 Text("사진 앱에 저장")

--- a/Presentation/OriginalPaper/Floating/FloatingView.swift
+++ b/Presentation/OriginalPaper/Floating/FloatingView.swift
@@ -90,7 +90,7 @@ struct FloatingView: View {
                         self.floatingViewModel.saveFigAlert()
                         self.isSavedLocation = true
                         
-                        print("Download Image")
+                        log("Download Image")
                         
                     }, label: {
                         Text("사진 앱에 저장")

--- a/Presentation/OriginalPaper/Index/IndexCell.swift
+++ b/Presentation/OriginalPaper/Index/IndexCell.swift
@@ -87,7 +87,7 @@ struct IndexCell: View {
         if let destination = item.table.destination {
             self.indexViewModel.selectedDestination = destination
         } else {
-            print("No destination")
+            log("No destination")
         }
     }
 }

--- a/Presentation/OriginalPaper/Menus/Comment/CommentGroupView.swift
+++ b/Presentation/OriginalPaper/Menus/Comment/CommentGroupView.swift
@@ -30,9 +30,6 @@ struct CommentGroupView: View {
             .cornerRadius(16)
             .shadow(color: Color(hex: "#6E6E6E").opacity(0.25), radius: 10, x: 0, y: 2)
         }
-        .onChange(of: viewModel.isEditMode) {
-            print("editmode")
-        }
     }
 }
 

--- a/Presentation/OriginalPaper/Menus/Drawing/PDFDrawer.swift
+++ b/Presentation/OriginalPaper/Menus/Drawing/PDFDrawer.swift
@@ -264,7 +264,7 @@ extension PDFDrawer: DrawingGestureRecognizerDelegate {
                 let rectanglePath = UIBezierPath(rect: CGRect(x: topLeft.x, y: topLeft.y, width: width, height: height))
 
                 if let newFigure = captureToPDF(path: rectanglePath) {
-                    print("PDF is captured: \(newFigure)")
+                    log("PDF is captured: \(newFigure)")
                     endCaptureMode()
                 }
                 

--- a/Presentation/OriginalPaper/Menus/FigureList/Collection/CollectionMenu.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Collection/CollectionMenu.swift
@@ -33,8 +33,6 @@ struct CollectionMenu: View {
                         self.focusFigureViewModel.selectedID = id
                         self.focusFigureViewModel.isFigure = false
                         
-                        print("Edit FigName")
-                        
                     }, label: {
                         HStack {
                             Text("이름 수정")
@@ -58,9 +56,6 @@ struct CollectionMenu: View {
                         floatingViewModel.saveFigAlert()
                         self.focusFigureViewModel.selectedID = id
                         self.isSavedLocation = true
-                        
-                        print("Save Fig")
-                        
                     }, label: {
                         HStack {
                             Text("사진 앱에 저장")

--- a/Presentation/OriginalPaper/Menus/FigureList/Collection/CollectionView.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Collection/CollectionView.swift
@@ -115,7 +115,6 @@ struct CollectionView: View {
                                     withAnimation {
                                         // 자동 스크롤
                                         proxy.scrollTo(id, anchor: .top)
-                                        print(id)
                                     }
                                 }
                             }
@@ -134,10 +133,6 @@ struct CollectionView: View {
                         
                         mainPDFViewModel.statusStack.captureToggle()
                         mainPDFViewModel.statusStack.centerMenuOff()
-                        
-                        print(mainPDFViewModel.statusStack.isCollectionSelected,
-                              mainPDFViewModel.statusStack.isCaptureSelected,
-                              focusFigureViewModel.isCaptureMode)
                     }) {
                         ZStack(alignment: .top) {
                             RoundedRectangle(cornerRadius: 8)

--- a/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureMenu.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureMenu.swift
@@ -33,9 +33,6 @@ struct FigureMenu: View {
                         focusFigureViewModel.isEditFigName = true
                         self.focusFigureViewModel.selectedID = id
                         self.focusFigureViewModel.isFigure = true
-                        
-                        print("Edit FigName")
-                        
                     }, label: {
                         HStack {
                             Text("이름 수정")
@@ -59,9 +56,6 @@ struct FigureMenu: View {
                         floatingViewModel.saveFigAlert()
                         self.focusFigureViewModel.selectedID = id
                         self.isSavedLocation = true
-                        
-                        print("Save Fig")
-                        
                     }, label: {
                         HStack {
                             Text("사진 앱에 저장")

--- a/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureView.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/Figure/FigureView.swift
@@ -122,7 +122,7 @@ private struct FigureCompleteView: View {
                     Button(action: {
                         if let figure = focusFigureViewModel.figures.first {
                             guard let document = focusFigureViewModel.setFigureDocument(for: 0) else {
-                                print("Failed to set figure document.")
+                                log("Failed to set figure document.")
                                 return
                             }
                             let head = figure.head
@@ -241,7 +241,6 @@ private struct FigureCompleteView: View {
                             withAnimation {
                                 // 자동 스크롤
                                 proxy.scrollTo(id, anchor: .top)
-                                print(id)
                             }
                         }
                     }

--- a/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
+++ b/Presentation/OriginalPaper/Menus/FigureList/ViewModel/FocusFigureViewModel.swift
@@ -119,7 +119,7 @@ extension FocusFigureViewModel {
             }
             
         case .failure(let failure):
-            print(failure)
+            log(failure)
         }
     }
     
@@ -194,7 +194,7 @@ extension FocusFigureViewModel {
             self.focusFigureUseCase.editPaperInfo(info: paperInfo)
             DispatchQueue.main.async {
                 self.focusStatus = .empty
-                print(error)
+                log(error)
             }
         }
     }
@@ -250,7 +250,7 @@ extension FocusFigureViewModel {
                     
                     DispatchQueue.main.async {
                         self.figureStatus = .empty
-                        print(error)
+                        log(error)
                     }
                 }
             }
@@ -293,7 +293,7 @@ extension FocusFigureViewModel {
     
     public func setFigureDocument(for index: Int) -> PDFDocument? {
         guard index >= 0 && index < self.figures.count else {
-            print("Invalid index")
+            log("Invalid index")
             return nil
         }
         
@@ -302,7 +302,7 @@ extension FocusFigureViewModel {
         
         guard let page = self.focusFigureUseCase.pdfSharedData.document?.page(at: annotation.page - 1)?.copy()
                 as? PDFPage else {
-            print("Failed to get page")
+            log("Failed to get page")
             return nil
         }
         
@@ -320,7 +320,7 @@ extension FocusFigureViewModel {
     
     public func setCollectionDocument(for index: Int) -> PDFDocument? {
         guard index >= 0 && index < self.collections.count else {
-            print("Invalid index")
+            log("Invalid index")
             return nil
         }
         
@@ -329,7 +329,7 @@ extension FocusFigureViewModel {
         
         guard let page = self.focusFigureUseCase.pdfSharedData.document?.page(at: annotation.page - 1)?.copy()
                 as? PDFPage else {
-            print("Failed to get page")
+            log("Failed to get page")
             return nil
         }
         

--- a/Presentation/OriginalPaper/Menus/PageList/Views/ThumbnailTableViewController.swift
+++ b/Presentation/OriginalPaper/Menus/PageList/Views/ThumbnailTableViewController.swift
@@ -88,7 +88,7 @@ extension ThumbnailTableViewController {
                                 animated: true
                             )
                         } else {
-                            print("Invalid row: \(targetRow). Total rows: \(totalRows)")
+                            log("Invalid row: \(targetRow). Total rows: \(totalRows)")
                         }
                     }
                 }

--- a/Presentation/OriginalPaper/Menus/Translation/TranslationManager.swift
+++ b/Presentation/OriginalPaper/Menus/Translation/TranslationManager.swift
@@ -39,7 +39,6 @@ public final class TranslationManager {
     var selectedText: String = "" {
         didSet {
             updateTranslationView(bubblePosition: translateViewPosition)
-            print(selectedText)
         }
     }
     
@@ -76,8 +75,7 @@ public final class TranslationManager {
                 AnalyticsManager.sendEvent(eventType: .translationTriggered, parameters: "\(wordCount)")
             }
         } catch {
-            print("translation do-catch")
-            print(error.localizedDescription)
+            log(error.localizedDescription)
         }
     }
     

--- a/Presentation/OriginalPaper/OriginalView.swift
+++ b/Presentation/OriginalPaper/OriginalView.swift
@@ -24,7 +24,7 @@ struct OriginalView: View {
     
     @State private var orientation: LayoutOrientation = .horizontal
     
-    private let screenHeight = UIScreen.main.bounds.height
+//    private let screenHeight = UIScreen.main.bounds.height
     
     private let publisher = NotificationCenter.default.publisher(for: .isCommentTapped)
     

--- a/Presentation/OriginalPaper/OriginalViewController.swift
+++ b/Presentation/OriginalPaper/OriginalViewController.swift
@@ -266,7 +266,6 @@ extension OriginalViewController {
         
         self.viewModel.$statusStack
             .sink { [weak self] statusStack in
-                print("First: ", statusStack)
                 self?.mainPDFView.performActionFlag = statusStack.isCenterMenuSelected
                 self?.updateGestureRecognizer(statusStack: statusStack)
             }
@@ -322,7 +321,7 @@ extension OriginalViewController {
                     self?.backpageBtnViewModel.handleBtnVisible()
                     
                 } else {
-                    print("Document or page is nil")
+                    log("Document or page is nil")
                 }
             }
             .store(in: &self.cancellable)

--- a/Presentation/OriginalPaper/OriginalViewController.swift
+++ b/Presentation/OriginalPaper/OriginalViewController.swift
@@ -208,6 +208,13 @@ extension OriginalViewController {
         pencilInteraction.isEnabled = true
         pencilInteraction.delegate = self
         self.view.addInteraction(pencilInteraction)
+        
+        // Mac에서 실행 시 PDFAnnotation 탭 제스쳐 추가
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            let gesture = UITapGestureRecognizer()
+            gesture.delegate = self
+            self.mainPDFView.addGestureRecognizer(gesture)
+        }
     }
     
     /// 데이터 Binding
@@ -273,6 +280,7 @@ extension OriginalViewController {
         
         NotificationCenter.default.publisher(for: .PDFViewAnnotationHit)
             .sink { [weak self] notification in
+                if ProcessInfo.processInfo.isiOSAppOnMac { return }
                 guard let self = self else { return }
                 
                 if let annotation = notification.userInfo?["PDFAnnotationHit"] as? PDFAnnotation {
@@ -455,15 +463,39 @@ extension OriginalViewController {
 
 // MARK: - 탭 제스처 관련
 extension OriginalViewController: UIGestureRecognizerDelegate {
-    
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         let location = touch.location(in: mainPDFView)
         
-        // 버튼 annotation이 있는 위치인지 확인
+        // annotation이 있는 위치인지 확인
+        // Mac에서 실행할 시 제스쳐
         if let page = mainPDFView.page(for: location, nearest: true),
            let annotation = page.annotation(at: mainPDFView.convert(location, to: page)),
-           annotation.widgetFieldType == .button {
-            return true
+           let type = annotation.type {
+            
+            if type == "Link", let action = annotation.action {
+                backpageBtnViewModel.backScaleFactor = mainPDFView.scaleFactor
+                backpageBtnViewModel.setDestination(pdfView: self.mainPDFView)
+                backpageBtnViewModel.delayBtnVisible(after: 0.8)
+                
+                self.mainPDFView.perform(action)
+                return true
+            } else if type == "Stamp" {
+                self.viewModel.isCommentTapped.toggle()
+                self.commentViewModel.isMenuTapped = false
+                
+                if self.viewModel.isCommentTapped, let buttonID = annotation.contents {
+                    let splittedContents = buttonID.split(separator: "|")
+                    let selectedComments = self.commentViewModel.comments.filter {
+                        $0.buttonId.uuidString == (splittedContents.count > 1 ? splittedContents.last! : splittedContents[0])
+                    }
+                    
+                    self.viewModel.selectedComments = selectedComments
+                    self.commentViewModel.setCommentPosition(selectedComments: self.viewModel.selectedComments, pdfView: self.mainPDFView)
+                }
+                self.viewModel.setHighlight(selectedComments: self.viewModel.selectedComments, isTapped: self.viewModel.isCommentTapped)
+                return true
+            }
+            
         }
         return false
     }

--- a/Reazy.xcodeproj/project.pbxproj
+++ b/Reazy.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		2C5C24172CE9DB9E00C37A1B /* PDFUploadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5C24162CE9DB9E00C37A1B /* PDFUploadError.swift */; };
 		2C5C241A2CE9E1A500C37A1B /* PDFSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5C24192CE9E1A500C37A1B /* PDFSharedData.swift */; };
 		2C6A13DD2CEE2D7300518986 /* FileManager + Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6A13DC2CEE2D7300518986 /* FileManager + Extension.swift */; };
+		2C9605DF2EDFFED400C67423 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 2C9605DE2EDFFED400C67423 /* FirebaseCrashlytics */; };
 		2CC431542CE9CA3E00E51DB0 /* HomeViewUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC431532CE9CA3E00E51DB0 /* HomeViewUseCase.swift */; };
 		2CC431572CE9CED500E51DB0 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC431562CE9CED500E51DB0 /* HomeViewModel.swift */; };
 		2CD48F562CFC3F8D004A5949 /* OrientationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD48F552CFC3F8D004A5949 /* OrientationManager.swift */; };
@@ -437,6 +438,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				67DA8C852CF7374300B232E2 /* FirebaseAnalytics in Frameworks */,
+				2C9605DF2EDFFED400C67423 /* FirebaseCrashlytics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -940,6 +942,7 @@
 				2C7AE8872CBCF290004098AF /* Frameworks */,
 				2C7AE8882CBCF290004098AF /* Resources */,
 				2C2C36D02CEC2EBC00552185 /* Embed Foundation Extensions */,
+				2C9604702EDFF4BD00C67423 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -967,6 +970,7 @@
 			name = Reazy;
 			packageProductDependencies = (
 				67DA8C842CF7374300B232E2 /* FirebaseAnalytics */,
+				2C9605DE2EDFFED400C67423 /* FirebaseCrashlytics */,
 			);
 			productName = Reazy;
 			productReference = 2C7AE88A2CBCF290004098AF /* Reazy.app */;
@@ -1057,6 +1061,32 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2C9604702EDFF4BD00C67423 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}.debug.dylib",
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		2C1458902CD7D09800B35D92 /* Sources */ = {
@@ -1483,6 +1513,7 @@
 				CODE_SIGN_ENTITLEMENTS = Reazy.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2025112101;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"Presentation/Preview Content\"";
 				DEVELOPMENT_TEAM = MT99YM3KLX;
 				ENABLE_PREVIEWS = YES;
@@ -1521,6 +1552,7 @@
 				CODE_SIGN_ENTITLEMENTS = Reazy.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2025112101;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"Presentation/Preview Content\"";
 				DEVELOPMENT_TEAM = MT99YM3KLX;
 				ENABLE_PREVIEWS = YES;
@@ -1613,6 +1645,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2C9605DE2EDFFED400C67423 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 67DA8C832CF7374300B232E2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
+		};
 		67DA8C842CF7374300B232E2 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 67DA8C832CF7374300B232E2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/Reazy.xcodeproj/project.pbxproj
+++ b/Reazy.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		2C1474402CE900A700B35D92 /* DrawingGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C14743B2CE900A700B35D92 /* DrawingGestureRecognizer.swift */; };
 		2C1474412CE900A700B35D92 /* PDFDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C14743C2CE900A700B35D92 /* PDFDrawer.swift */; };
 		2C1474422CE900A700B35D92 /* UIBezierPath+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C14743D2CE900A700B35D92 /* UIBezierPath+.swift */; };
+		2C202B392EDD694A00AB0459 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C202B382EDD694A00AB0459 /* Logger.swift */; };
 		2C2A56BE2D941BE100BEC95D /* HomeFolderPopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2A56BD2D941BE100BEC95D /* HomeFolderPopoverView.swift */; };
 		2C2C35882CEB1DCB00552185 /* DrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2C35872CEB1DCB00552185 /* DrawingView.swift */; };
 		2C2C358A2CEB24D800552185 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2C35892CEB24D800552185 /* MenuView.swift */; };
@@ -209,6 +210,7 @@
 		2C14743B2CE900A700B35D92 /* DrawingGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingGestureRecognizer.swift; sourceTree = "<group>"; };
 		2C14743C2CE900A700B35D92 /* PDFDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFDrawer.swift; sourceTree = "<group>"; };
 		2C14743D2CE900A700B35D92 /* UIBezierPath+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBezierPath+.swift"; sourceTree = "<group>"; };
+		2C202B382EDD694A00AB0459 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		2C2A56BD2D941BE100BEC95D /* HomeFolderPopoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeFolderPopoverView.swift; sourceTree = "<group>"; };
 		2C2C35872CEB1DCB00552185 /* DrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingView.swift; sourceTree = "<group>"; };
 		2C2C35892CEB24D800552185 /* MenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
@@ -667,6 +669,7 @@
 				2CDB3D362E335D3400609333 /* Set + Extension.swift */,
 				2CE05C1D2EB61C3D00341B46 /* MainPDFViewAction.swift */,
 				2CE05C212EB6290200341B46 /* AnalyticsManager.swift */,
+				2C202B382EDD694A00AB0459 /* Logger.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -1167,6 +1170,7 @@
 				2C1473CF2CE73B6F00B35D92 /* TranslateViewOlderVer.swift in Sources */,
 				2C1473D02CE73B6F00B35D92 /* CommentCell.swift in Sources */,
 				B3EE45672D43EFA8007804B9 /* BackPageBtnView.swift in Sources */,
+				2C202B392EDD694A00AB0459 /* Logger.swift in Sources */,
 				6E241BDE2CEDF47600AE3EB4 /* MoveFolderView.swift in Sources */,
 				2CC431572CE9CED500E51DB0 /* HomeViewModel.swift in Sources */,
 				B3F823412D4CE85300B9FBE9 /* BackPageBtnUseCase.swift in Sources */,


### PR DESCRIPTION
close #527 

## 변경 사항
- [x] Mac 실행시에만 Gesture를 추가 해 PDF내 Link Annotation 터치 액션 구현
- [x] Mac 실행시에만 Gesture를 추가 해 PDF내 코멘트 Annotation 터치 액션 구현

정확한 사유는 알 수 없지만 Mac에서 iOS 앱을 실행할 때 
SwiftUI의 Representable로 포팅되어 있는 UIKit 뷰를 사용하면 뷰 계층에 따라 UIKit 내부 뷰의 Hit Testing이 무시되는 현상이 있다고 합니다.
계층을 줄이는 것 또한 하나의 해결책이라고도 하는데 저희 뷰는 SwiftUI 기반이라 처리하기가 힘들어 그냥 임의의 TapGesture를 추가해 PDFAnnotation을 인식하는 것으로 변경했습니다.

## 스크린샷 or 영상 링크
### 링크 작동
<img width="1136" height="908" alt="스크린샷 2025-12-03 오후 2 30 42" src="https://github.com/user-attachments/assets/6fc7df80-6188-43d9-baf7-7a8303b244a1" />

### 코멘트 작동
<img width="1136" height="908" alt="스크린샷 2025-12-03 오후 2 31 14" src="https://github.com/user-attachments/assets/fa1264c8-4df6-4c12-a659-2c77695bea2c" />




