### PR TITLE
[Feat] Mac 버전 대응을 위한 우클릭 폴더 편집 옵션 제공

### DIFF
--- a/Domain/Extension/Locale+Extension.swift
+++ b/Domain/Extension/Locale+Extension.swift
@@ -1,5 +1,5 @@
 //
-//  Locale + Extension.swift
+//  Locale+Extension.swift
 //  Reazy
 //
 //  Created by 문인범 on 11/10/25.

--- a/Domain/Extension/View+RightClick.swift
+++ b/Domain/Extension/View+RightClick.swift
@@ -11,62 +11,124 @@ import UIKit
 extension View {
     func onMouse(
         onTap: @escaping () -> Void,
-        onRightClick: @escaping (CGRect) -> Void
+        onRightClick: @escaping (CGRect) -> Void,
+        onLongPress: @escaping (CGRect) -> Void,
+        onPressing: @escaping (Bool) -> Void
     ) -> some View {
-        self.overlay(
-            MouseClickView(onTap: onTap, onRightClick: onRightClick)
+        self.background(
+            MouseClickView(
+                onTap: onTap,
+                onRightClick: onRightClick,
+                onLongPress: onLongPress,
+                onPressing: onPressing
+            )
         )
     }
 }
 
+class TouchHandlingView: UIView {
+    var onPressing: ((Bool) -> Void)?
+    
+    private var workItem: DispatchWorkItem?
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        
+        let task = DispatchWorkItem { [weak self] in
+            self?.onPressing?(true)
+        }
+        self.workItem = task
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: task)
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        cancelAnimation()
+    }
+    
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesCancelled(touches, with: event)
+        cancelAnimation()
+    }
+    
+    private func cancelAnimation() {
+        if let item = workItem, !item.isCancelled {
+            item.cancel()
+        }
+        workItem = nil
+        
+        onPressing?(false)
+    }
+}
+
 struct MouseClickView: UIViewRepresentable {
-    typealias UIViewType = UIView
+    typealias UIViewType = TouchHandlingView
     
     var onTap: () -> Void
     var onRightClick: (CGRect) -> Void
+    var onLongPress: (CGRect) -> Void
+    var onPressing: (Bool) -> Void
     
-    func makeUIView(context: Context) -> UIView {
-        let view = UIView()
+    func makeUIView(context: Context) -> TouchHandlingView {
+        let view = TouchHandlingView()
         view.backgroundColor = .clear
         
+        let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        tap.cancelsTouchesInView = false
+        tap.delegate = context.coordinator
+        
         let rightClick = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleRightClick(_:)))
-        rightClick.allowedTouchTypes =  [NSNumber(value: UITouch.TouchType.indirectPointer.rawValue)]
+        rightClick.allowedTouchTypes = [NSNumber(value: UITouch.TouchType.indirectPointer.rawValue)]
         rightClick.buttonMaskRequired = .secondary
+        rightClick.cancelsTouchesInView = false
         rightClick.delegate = context.coordinator
         
-        let leftClick = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleLeftClick(_:)))
-        leftClick.delegate = context.coordinator
+        let longPress = UILongPressGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleLongPress(_:)))
+        longPress.minimumPressDuration = 0.5
+        longPress.cancelsTouchesInView = false
+        longPress.delegate = context.coordinator
         
+        view.addGestureRecognizer(tap)
         view.addGestureRecognizer(rightClick)
-        view.addGestureRecognizer(leftClick)
+        view.addGestureRecognizer(longPress)
         
         return view
     }
     
-    func updateUIView(_ uiView: UIView, context: Context) {}
+    func updateUIView(_ uiView: TouchHandlingView, context: Context) {
+        uiView.onPressing = onPressing
+        context.coordinator.parent = self
+    }
     
     func makeCoordinator() -> Coordinator {
-        Coordinator(onTap: onTap, onRightClick: onRightClick)
+        Coordinator(self)
     }
     
     class Coordinator: NSObject, UIGestureRecognizerDelegate {
-        var onTap: () -> Void
-        var onRightClick: (CGRect) -> Void
+        var parent: MouseClickView
         
-        init(onTap: @escaping () -> Void, onRightClick: @escaping (CGRect) -> Void) {
-            self.onTap = onTap
-            self.onRightClick = onRightClick
+        init(_ parent: MouseClickView) {
+            self.parent = parent
+        }
+        
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            parent.onTap()
         }
         
         @objc func handleRightClick(_ gesture: UITapGestureRecognizer) {
             guard let view = gesture.view else { return }
             let globalFrame = view.convert(view.bounds, to: nil)
-            
-            onRightClick(globalFrame)
+            parent.onRightClick(globalFrame)
         }
         
-        @objc func handleLeftClick(_ gesture: UITapGestureRecognizer) {
-            onTap()
+        @objc func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+            guard let view = gesture.view else { return }
+            if gesture.state == .began {
+                let globalFrame = view.convert(view.bounds, to: nil)
+                parent.onLongPress(globalFrame)
+                parent.onPressing(false)
+            }
         }
         
         func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {

--- a/Domain/Extension/View+RightClick.swift
+++ b/Domain/Extension/View+RightClick.swift
@@ -59,8 +59,11 @@ struct MouseClickView: UIViewRepresentable {
         }
         
         @objc func handleRightClick(_ gesture: UITapGestureRecognizer) {
-            let location = gesture.location(in: nil)
-            onRightClick(location)
+            guard let view = gesture.view else { return }
+            let localPoint = CGPoint(x: view.bounds.midX, y: view.bounds.maxY)
+            let globalFixedPoint = view.convert(localPoint, to: nil)
+            
+            onRightClick(globalFixedPoint)
         }
         
         @objc func handleLeftClick(_ gesture: UITapGestureRecognizer) {

--- a/Domain/Extension/View+RightClick.swift
+++ b/Domain/Extension/View+RightClick.swift
@@ -1,0 +1,74 @@
+//
+//  View+RightClick.swift
+//  Reazy
+//
+//  Created by 유지수 on 12/8/25.
+//
+
+import SwiftUI
+import UIKit
+
+extension View {
+    func onMouse(
+        onTap: @escaping () -> Void,
+        onRightClick: @escaping (CGPoint) -> Void
+    ) -> some View {
+        self.overlay(
+            MouseClickView(onTap: onTap, onRightClick: onRightClick)
+        )
+    }
+}
+
+struct MouseClickView: UIViewRepresentable {
+    typealias UIViewType = UIView
+    
+    var onTap: () -> Void
+    var onRightClick: (CGPoint) -> Void
+    
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+        
+        let rightClick = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleRightClick(_:)))
+        rightClick.allowedTouchTypes =  [NSNumber(value: UITouch.TouchType.indirectPointer.rawValue)]
+        rightClick.buttonMaskRequired = .secondary
+        rightClick.delegate = context.coordinator
+        
+        let leftClick = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleLeftClick(_:)))
+        leftClick.delegate = context.coordinator
+        
+        view.addGestureRecognizer(rightClick)
+        view.addGestureRecognizer(leftClick)
+        
+        return view
+    }
+    
+    func updateUIView(_ uiView: UIView, context: Context) {}
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onTap: onTap, onRightClick: onRightClick)
+    }
+    
+    class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var onTap: () -> Void
+        var onRightClick: (CGPoint) -> Void
+        
+        init(onTap: @escaping () -> Void, onRightClick: @escaping (CGPoint) -> Void) {
+            self.onTap = onTap
+            self.onRightClick = onRightClick
+        }
+        
+        @objc func handleRightClick(_ gesture: UITapGestureRecognizer) {
+            let location = gesture.location(in: nil)
+            onRightClick(location)
+        }
+        
+        @objc func handleLeftClick(_ gesture: UITapGestureRecognizer) {
+            onTap()
+        }
+        
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+            return true
+        }
+    }
+}

--- a/Domain/Extension/View+RightClick.swift
+++ b/Domain/Extension/View+RightClick.swift
@@ -11,7 +11,7 @@ import UIKit
 extension View {
     func onMouse(
         onTap: @escaping () -> Void,
-        onRightClick: @escaping (CGPoint) -> Void
+        onRightClick: @escaping (CGRect) -> Void
     ) -> some View {
         self.overlay(
             MouseClickView(onTap: onTap, onRightClick: onRightClick)
@@ -23,7 +23,7 @@ struct MouseClickView: UIViewRepresentable {
     typealias UIViewType = UIView
     
     var onTap: () -> Void
-    var onRightClick: (CGPoint) -> Void
+    var onRightClick: (CGRect) -> Void
     
     func makeUIView(context: Context) -> UIView {
         let view = UIView()
@@ -51,19 +51,18 @@ struct MouseClickView: UIViewRepresentable {
     
     class Coordinator: NSObject, UIGestureRecognizerDelegate {
         var onTap: () -> Void
-        var onRightClick: (CGPoint) -> Void
+        var onRightClick: (CGRect) -> Void
         
-        init(onTap: @escaping () -> Void, onRightClick: @escaping (CGPoint) -> Void) {
+        init(onTap: @escaping () -> Void, onRightClick: @escaping (CGRect) -> Void) {
             self.onTap = onTap
             self.onRightClick = onRightClick
         }
         
         @objc func handleRightClick(_ gesture: UITapGestureRecognizer) {
             guard let view = gesture.view else { return }
-            let localPoint = CGPoint(x: view.bounds.midX, y: view.bounds.maxY)
-            let globalFixedPoint = view.convert(localPoint, to: nil)
+            let globalFrame = view.convert(view.bounds, to: nil)
             
-            onRightClick(globalFixedPoint)
+            onRightClick(globalFrame)
         }
         
         @objc func handleLeftClick(_ gesture: UITapGestureRecognizer) {

--- a/Presentation/Home/HomeListView.swift
+++ b/Presentation/Home/HomeListView.swift
@@ -225,10 +225,22 @@ private struct FolderListCell: View {
                 onTap: {
                     didSelectFolder(folder.id)
                 },
-                onRightClick: { globalPoint in
+                onRightClick: { globalFrame in
                     homeViewModel.homeViewStatus = .folder(folder.id)
+                    
+                    let screenHeight = UIScreen.main.bounds.height
+                    let popoverHeight: CGFloat = 170
+                    let spaceBelow = screenHeight - globalFrame.maxY
+                    var finalY: CGFloat = 0
+                    
+                    if spaceBelow < popoverHeight {
+                        finalY = globalFrame.maxY - popoverHeight + 30
+                    } else {
+                        finalY = globalFrame.maxY + 10
+                    }
+                    
                     homeViewModel.homeViewAction = .folderPopover(
-                        position: .init(x: 140, y: globalPoint.y)
+                        position: .init(x: 140, y: finalY)
                     )
                 }
             )

--- a/Presentation/Home/HomeListView.swift
+++ b/Presentation/Home/HomeListView.swift
@@ -202,9 +202,6 @@ private struct FolderListCell: View {
             .background(homeViewModel.homeViewStatus.currentFolderID == folder.id ? .gray300 : .clear)
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .contentShape(Rectangle())
-            .onTapGesture {
-                didSelectFolder(folder.id)
-            }
             .gesture(
                 LongPressGesture(minimumDuration: 0.5)
                     .sequenced(before: DragGesture(minimumDistance: 0, coordinateSpace: .global))
@@ -224,9 +221,20 @@ private struct FolderListCell: View {
                         }
                     }
             )
+            .onMouse(
+                onTap: {
+                    didSelectFolder(folder.id)
+                },
+                onRightClick: { globalPoint in
+                    homeViewModel.homeViewStatus = .folder(folder.id)
+                    homeViewModel.homeViewAction = .folderPopover(
+                        position: .init(x: 140, y: globalPoint.y + 85)
+                    )
+                }
+            )
             .scaleEffect((animationFolder == folder && highlight) ? 1.2 : 1)
             .dropDestination(for: PaperInfo.self) { droppedItems, location in
-                if let droppedItem = droppedItems.first {
+                        if let droppedItem = droppedItems.first {
                     handleDrop(folder.id, droppedItem)
                     return true
                 }

--- a/Presentation/Home/HomeListView.swift
+++ b/Presentation/Home/HomeListView.swift
@@ -228,7 +228,7 @@ private struct FolderListCell: View {
                 onRightClick: { globalPoint in
                     homeViewModel.homeViewStatus = .folder(folder.id)
                     homeViewModel.homeViewAction = .folderPopover(
-                        position: .init(x: 140, y: globalPoint.y + 85)
+                        position: .init(x: 140, y: globalPoint.y)
                     )
                 }
             )

--- a/Presentation/Home/HomeListView.swift
+++ b/Presentation/Home/HomeListView.swift
@@ -155,7 +155,7 @@ private struct FolderListCell: View {
     
     @State private var animationFolder: Folder?
     var onLongPressGesture: (Folder, DragGesture.Value?) -> Void
-    @GestureState private var highlight = false
+    @State private var highlight = false
     
     var body: some View {
         VStack(spacing: 0) {
@@ -171,27 +171,37 @@ private struct FolderListCell: View {
                     )
                     .padding(.leading, 20)
                     .padding(.trailing, 10)
+                    .allowsHitTesting(false)
                 
                 VStack(spacing: 0) {
                     Spacer()
                     
                     HStack(spacing: 0) {
-                        Text(folder.title)
-                            .reazyFont(.text1)
-                            .foregroundStyle(.gray700)
-                        
-                        Spacer()
+                        HStack(spacing: 0) {
+                            Text(folder.title)
+                                .reazyFont(.text1)
+                                .foregroundStyle(.gray700)
+                            
+                            Spacer()
+                        }
+                        .allowsHitTesting(false)
                         
                         if hasChildren(folder) {
-                            Button(action: {
-                                toggleExpansion(folder)
-                            }) {
-                                Image(systemName: homeViewModel.expandedFolders.contains(folder.id) ? "chevron.down" : "chevron.right")
-                                    .font(.system(size: 12, weight: .medium))
-                                    .foregroundStyle(.gray600)
-                                    .padding(.trailing, 4)
-                            }
-                            .padding(.trailing, 10)
+                            Image(systemName: homeViewModel.expandedFolders.contains(folder.id) ? "chevron.down" : "chevron.right")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.gray600)
+                                .padding(.trailing, 14)
+                                .overlay(
+                                    Color.clear
+                                        .frame(width: 44, height: 44)
+                                        .contentShape(Rectangle())
+                                        .highPriorityGesture(
+                                            TapGesture()
+                                                .onEnded {
+                                                    toggleExpansion(folder)
+                                                }
+                                        )
+                                )
                         }
                     }
                     
@@ -199,52 +209,32 @@ private struct FolderListCell: View {
                 }
             }
             .padding(.leading, CGFloat((level * 18)))
-            .background(homeViewModel.homeViewStatus.currentFolderID == folder.id ? .gray300 : .clear)
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .contentShape(Rectangle())
-            .gesture(
-                LongPressGesture(minimumDuration: 0.5)
-                    .sequenced(before: DragGesture(minimumDistance: 0, coordinateSpace: .global))
-                    .updating($highlight) { currentState, gestureState, transaction in
-                        if case .second(true, _) = currentState {
-                            self.animationFolder = folder
-                            transaction.animation = .easeIn(duration: 1)
-                            gestureState = true
-                        }
-                    }
-                    .onEnded { value in
-                        switch value {
-                        case .second(true, let drag):
-                            onLongPressGesture(folder, drag)
-                        default:
-                            break
-                        }
-                    }
+            .background(
+                (homeViewModel.homeViewStatus.currentFolderID == folder.id ? Color.gray300 : .clear)
+                    .allowsHitTesting(false)
             )
+            .clipShape(RoundedRectangle(cornerRadius: 12))
             .onMouse(
                 onTap: {
                     didSelectFolder(folder.id)
                 },
                 onRightClick: { globalFrame in
-                    homeViewModel.homeViewStatus = .folder(folder.id)
-                    
-                    let screenHeight = UIScreen.main.bounds.height
-                    let popoverHeight: CGFloat = 170
-                    let spaceBelow = screenHeight - globalFrame.maxY
-                    var finalY: CGFloat = 0
-                    
-                    if spaceBelow < popoverHeight {
-                        finalY = globalFrame.maxY - popoverHeight + 30
-                    } else {
-                        finalY = globalFrame.maxY + 10
+                    showPopover(frame: globalFrame)
+                },
+                onLongPress: { globalFrame in
+                    self.animationFolder = folder
+                    showPopover(frame: globalFrame)
+                },
+                onPressing: { isPressing in
+                    withAnimation(.easeInOut(duration: 0.5)) {
+                        if isPressing {
+                            self.animationFolder = folder
+                        }
+                        self.highlight = isPressing
                     }
-                    
-                    homeViewModel.homeViewAction = .folderPopover(
-                        position: .init(x: 140, y: finalY)
-                    )
                 }
             )
-            .scaleEffect((animationFolder == folder && highlight) ? 1.2 : 1)
+            .scaleEffect((animationFolder == folder && highlight) ? 1.1 : 1)
             .dropDestination(for: PaperInfo.self) { droppedItems, location in
                         if let droppedItem = droppedItems.first {
                     handleDrop(folder.id, droppedItem)
@@ -272,6 +262,25 @@ private struct FolderListCell: View {
                 EmptyView()
             }
         }
+    }
+    
+    private func showPopover(frame globalFrame: CGRect) {
+        homeViewModel.homeViewStatus = .folder(folder.id)
+        
+        let screenHeight = UIScreen.main.bounds.height
+        let popoverHeight: CGFloat = 170
+        let spaceBelow = screenHeight - globalFrame.maxY
+        var finalY: CGFloat = 0
+        
+        if spaceBelow < popoverHeight {
+            finalY = globalFrame.maxY - popoverHeight + 30
+        } else {
+            finalY = globalFrame.maxY + 10
+        }
+        
+        homeViewModel.homeViewAction = .folderPopover(
+            position: .init(x: 140, y: finalY)
+        )
     }
 }
 


### PR DESCRIPTION
## 변경 사항
- [ ] 기존에 `LongPress`로만 띄울 수 있던 폴더 편집 옵션을 마우스 우클릭 (트랙패드 두 손가락 클릭)으로 띄울 수 있도록 수정하였습니다.
- [ ] 기본으로 제공되는 `TapGesture`과 마우스 우클릭을 위한 제스처를 따로 두게 될 경우, 두 개의 탭 제스처가 중복되어 하나의 제스처는 무시당하는 현상이 발생하였습니다. 따라 `onTap`과 `onRightClick`, `onLongPress`를 구분하여 알맞는 제스처를 적용하는 View Extension을 추가하였습니다.
``` Swift
extension View {
    func onMouse(
        onTap: @escaping () -> Void,
        onRightClick: @escaping (CGRect) -> Void,
        onLongPress: @escaping (CGRect) -> Void,
        onPressing: @escaping (Bool) -> Void
    ) -> some View {
        self.background(
            MouseClickView(
                onTap: onTap,
                onRightClick: onRightClick,
                onLongPress: onLongPress,
                onPressing: onPressing
            )
        )
    }
}
```
_**‼️ 하나의 셀에 다양한 제스처가 들어가게 되면 임의로 넣은 UIView의 제스처와 SwiftUI 기본 제공 `onTapGesture`간의 충돌로 인해 일부 터치 이벤트가 작용하지 않을 수 있습니다. 따라, 네 개의 제스처를 구분할 수 있는 UIView로 통합하여 `FolderListCell`의 제스처를 명확하게 분류하였습니다. ‼️**_


## 스크린샷 or 영상 링크
https://github.com/user-attachments/assets/e574c6a0-abc0-4eee-a48f-5b3b5d987d96



## 팀원에게 전달할 사항(Optional)
| 오랜만입니다~ 수정할 사항이 추가로 있다면 또 말씀해 주세요! 이해 안 가는 부분이 있다면 그 또한 환영입니다 :)!!!!!
브랜치 이름은... 새로운 기능이긴 해서 Feat으로 붙어야 할지 Fix로 붙어야 할지 애매한데 여러분의 생각은 어떠신가요

close #526 
