### PR TITLE
[Feat] Reazy 최소 창크기 설정

### DIFF
--- a/Presentation/AppView.swift
+++ b/Presentation/AppView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import FirebaseCore
+import UIKit
 
 @main
 struct AppView: App {
@@ -70,6 +71,38 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         UIView.appearance().tintColor = UIColor.primary1
 
         return true
+    }
+    
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        let sceneConfiguration = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
+        sceneConfiguration.delegateClass = SceneDelegate.self
+        return sceneConfiguration
+    }
+}
+
+class SceneDelegate: NSObject, UIWindowSceneDelegate {
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        
+        // Mac 환경 감지 (Mac Catalyst 또는 Mac에서 실행되는 iPad 앱)
+        let isMac: Bool = {
+            #if targetEnvironment(macCatalyst)
+            return true
+            #else
+            if #available(iOS 14.0, *) {
+                return ProcessInfo.processInfo.isiOSAppOnMac
+            }
+            return false
+            #endif
+        }()
+        
+        if isMac {
+            // Mac 환경: 최소 크기 700x500
+            windowScene.sizeRestrictions?.minimumSize = CGSize(width: 800, height: 500)
+        } else if UIDevice.current.userInterfaceIdiom == .pad {
+            // iPad 환경: 최소 크기 600x300
+            windowScene.sizeRestrictions?.minimumSize = CGSize(width: 700, height: 400)
+        }
     }
 }
 

--- a/Presentation/AppView.swift
+++ b/Presentation/AppView.swift
@@ -97,11 +97,14 @@ class SceneDelegate: NSObject, UIWindowSceneDelegate {
         }()
         
         if isMac {
-            // Mac 환경: 최소 크기 700x500
-            windowScene.sizeRestrictions?.minimumSize = CGSize(width: 800, height: 500)
+            // Mac 환경: 최소 크기 696x464
+            windowScene.sizeRestrictions?.minimumSize = CGSize(width: 696, height: 464)
         } else if UIDevice.current.userInterfaceIdiom == .pad {
-            // iPad 환경: 최소 크기 600x300
-            windowScene.sizeRestrictions?.minimumSize = CGSize(width: 700, height: 400)
+            // iPad 환경: 화면 크기 기반 (가로 1/2) x (세로 2/3)
+            let screenSize = windowScene.screen.bounds.size
+            let minWidth = screenSize.width / 2
+            let minHeight = screenSize.height * (2.0 / 3.0)
+            windowScene.sizeRestrictions?.minimumSize = CGSize(width: minWidth, height: minHeight)
         }
     }
 }

--- a/Presentation/Helper/OrientationManager.swift
+++ b/Presentation/Helper/OrientationManager.swift
@@ -6,7 +6,7 @@
 //
 
 import UIKit
-import SwiftUICore
+import SwiftUI
 import Combine
 
 

--- a/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
+++ b/Presentation/Home/HomeSearch/ViewModel/HomeSearchViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import SwiftUICore
+import SwiftUI
 
 @MainActor
 final class HomeSearchViewModel: ObservableObject, Sendable {


### PR DESCRIPTION
## 변경 사항
- [x] iPad에서 최소 창크기를 적용합니다.
- [x] mac에서 최소 창크기를 적용합니다.


## 스크린샷 or 영상 링크
|

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/4bf96d75-0e7f-4d82-89c3-42612e146006" width="400"></td>
    <td><img src="https://github.com/user-attachments/assets/204772ac-6f71-4940-aa60-1ab739636b2f" width="400"></td>
  </tr>
  <tr>
    <td align="center">[ iPad 최소 창크기 적용 ]</td>
    <td align="center">[ mac 최소 창크기 적용 ]</td>
  </tr>
</table>


## 팀원에게 전달할 사항(Optional)
|
mac에서는 최소 창크기를 696x464, iPad에서는 (너비의 1/2)x(높이의 2/3) (width x height)를 적용하였습니다.
제가 조절해보며 적당한 크기로 적용했습니다.

참고로 iPad에서 Pad에서는 (너비의 1/2)x(높이의 2/3) (width x height)를 적용하니 Reazy앱이 1:1 비율이 나오게 됩니다.

close #528 