### PR TITLE
[#548] 아이패드 최소창 좌측 메뉴바 수정

### DIFF
--- a/Presentation/Home/HomeListView.swift
+++ b/Presentation/Home/HomeListView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct HomeListView: View {
-    @EnvironmentObject private var homeViewModel: HomeViewModel
     
+    @EnvironmentObject private var homeViewModel: HomeViewModel
   
     var body: some View {
         VStack(spacing: 0) {

--- a/Presentation/Home/HomeView.swift
+++ b/Presentation/Home/HomeView.swift
@@ -298,7 +298,7 @@ struct HomeView: View {
     private func SidePanelView(geometry: GeometryProxy) -> some View {
         if homeViewModel.homeViewStatus != .edit {
             HomeListView()
-                .frame(width: geometry.size.width / 4)
+                .frame(width: max(geometry.size.width / 4, 216))
         }
     }
     


### PR DESCRIPTION
## 변경 사항
- [x] 아이패드에서 최소창 시에 좌측 메뉴바의 최소 크기를 지정하여 일정 크기 이상 작아지지 않아 불편함을 줄였습니다.


## 스크린샷 or 영상 링크
|


https://github.com/user-attachments/assets/02cf0ca8-f67b-4de0-ab13-0e5794285686



## 팀원에게 전달할 사항(Optional)
|

좌측 탭바의 크기를 아이패드 너비의의 1/4로 유지되다가 width가 216부터는 유지되도록 수정하여 메뉴바가 너무 작아지는 것을 방지하였습니다.

close #548 