### PR TITLE
[Fix] 맥북 올가미 취소 버튼 동작

### DIFF
--- a/Presentation/OriginalPaper/OriginalViewController.swift
+++ b/Presentation/OriginalPaper/OriginalViewController.swift
@@ -733,22 +733,26 @@ extension OriginalViewController: UIGestureRecognizerDelegate {
     // Mac 캡쳐 오버레이 표시 - 모아보기, figure 추가용
     private func showCaptureOverlay() {
         guard captureOverlayView == nil else { return }
-        guard let window = self.view.window else { return }
-        
+
         let overlay = UIView()
-        overlay.frame = window.bounds
-        overlay.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        overlay.translatesAutoresizingMaskIntoConstraints = false
         overlay.backgroundColor = .clear
         overlay.isUserInteractionEnabled = true
-        
+
         let pan = UIPanGestureRecognizer(target: self, action: #selector(handleMacCapturePan(_:)))
         overlay.addGestureRecognizer(pan)
-        
+
         // 탭 제스처 추가 - 체크버튼 탭 감지용
         let tap = UITapGestureRecognizer(target: self, action: #selector(handleMacCaptureTap(_:)))
         overlay.addGestureRecognizer(tap)
-        
-        window.insertSubview(overlay, at: window.subviews.count)
+
+        mainPDFView.addSubview(overlay)
+        NSLayoutConstraint.activate([
+            overlay.topAnchor.constraint(equalTo: mainPDFView.topAnchor),
+            overlay.bottomAnchor.constraint(equalTo: mainPDFView.bottomAnchor),
+            overlay.leadingAnchor.constraint(equalTo: mainPDFView.leadingAnchor),
+            overlay.trailingAnchor.constraint(equalTo: mainPDFView.trailingAnchor),
+        ])
         self.captureOverlayView = overlay
     }
 


### PR DESCRIPTION
## 변경 사항
- [x] 맥북에서 올가미(캡쳐) 모드의 취소 버튼 탭이 동작하지 않던 문제 수정

## 원인
`showCaptureOverlay()`에서 캡쳐 오버레이를 `window` 전체에 덮어씌우고 있어, 사이드바의 "취소" 버튼 탭 이벤트가 오버레이의 `UITapGestureRecognizer`에 먼저 흡수되어 SwiftUI 버튼까지 도달하지 못했습니다.

## 해결 방법
오버레이를 `window` 대신 `mainPDFView`의 subview로 붙이고 Auto Layout으로 PDF 영역에만 한정. 사이드바 영역은 오버레이에 가려지지 않아 취소 버튼 탭이 정상 전달됩니다.

## 팀원에게 전달할 사항(Optional)
|