### PR TITLE
[Fix] 맥북에서 올가미 안되는 오류, 아이패드 올가미 오류

### DIFF
--- a/Presentation/OriginalPaper/Menus/Drawing/PDFDrawer.swift
+++ b/Presentation/OriginalPaper/Menus/Drawing/PDFDrawer.swift
@@ -331,6 +331,8 @@ extension PDFDrawer: DrawingGestureRecognizerDelegate {
             checkButton.tintColor = .gray100
             checkButton.backgroundColor = .point4
             checkButton.layer.cornerRadius = 10
+            checkButton.isUserInteractionEnabled = false
+            
             pdfView.addSubview(checkButton)
 
             return

--- a/Presentation/OriginalPaper/OriginalViewController.swift
+++ b/Presentation/OriginalPaper/OriginalViewController.swift
@@ -693,7 +693,6 @@ extension OriginalViewController: UIGestureRecognizerDelegate {
         }
         
         self.mainPDFView.addGestureRecognizer(pdfDrawingGestureRecognizer)
-        pdfDrawingGestureRecognizer.delegate = self
         pdfDrawingGestureRecognizer.drawingDelegate = viewModel.pdfDrawer
         viewModel.pdfDrawer.pdfView = self.mainPDFView
         


### PR DESCRIPTION
## 변경 사항
- [ ] 맥북에서 올가미 안되는 오류, 
- [ ] 아이패드 올가미 시 pdf 스크롤 되는 오류


## 스크린샷 or 영상 링크
|


## 팀원에게 전달할 사항(Optional)
| 
맥북에서 올가미 : overlay 뷰 위에 체크버튼이 올라가 있어서 실제 체크버튼의 제스처를 가로채고 있었음
아이패드 스크롤 이슈 : pdfDrawingGestureRecognizer.delegate = self 해당 코드 삭제 시 원활하게 동작되는 점 확인하여 삭제

- 동작 확인한 케이스
아이패드 & 맥북에서 하이라이트 및 지우개, 올가미&올가미 취소 

